### PR TITLE
fix: align csproj version to published NuGet baseline (0.1.0 → 0.1.1)

### DIFF
--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.1.0</Version>
+		<Version>0.1.1</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>


### PR DESCRIPTION
## Summary
- `Agency.csproj` declared `Version=0.1.0` but the published NuGet package is `0.1.1`
- Aligns the source version metadata with the actual published baseline

Closes #2

## Test plan
- [x] Version string matches nuget.org published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)