### PR TITLE
docs: fill empty XML documentation comments

### DIFF
--- a/agency/IAgency.cs
+++ b/agency/IAgency.cs
@@ -1,5 +1,8 @@
 ﻿namespace ShareInvest.Agency;
 
+/// <summary>
+/// Core contract for AI agency services in the PageMint ecosystem, including batch image generation and title generation.
+/// </summary>
 public interface IAgency
 {
 

--- a/agency/Models/ImageGenerationModerationException.cs
+++ b/agency/Models/ImageGenerationModerationException.cs
@@ -5,11 +5,20 @@
 /// </summary>
 public class ImageGenerationModerationException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="ImageGenerationModerationException"/> with the moderation rejection message.
+    /// </summary>
+    /// <param name="message">The message describing why the image generation request was rejected.</param>
     public ImageGenerationModerationException(string message) : base(message)
     {
 
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ImageGenerationModerationException"/> with a rejection message and an inner exception.
+    /// </summary>
+    /// <param name="message">The message describing why the image generation request was rejected.</param>
+    /// <param name="innerException">The underlying exception that caused this exception to be thrown.</param>
     public ImageGenerationModerationException(string message, Exception innerException) : base(message, innerException)
     {
 

--- a/agency/Models/ImageGenerationRequest.cs
+++ b/agency/Models/ImageGenerationRequest.cs
@@ -2,4 +2,14 @@
 
 namespace ShareInvest.Agency.Models;
 
+/// <summary>
+/// Represents the parameters required to request an AI-generated image for a specific scene in a PageMint project.
+/// </summary>
+/// <param name="UserId">The identifier of the user who owns the project.</param>
+/// <param name="Path">The storage path where the generated image will be saved.</param>
+/// <param name="SceneId">The identifier of the scene for which the image is being generated.</param>
+/// <param name="Prompt">The text prompt describing the image to generate.</param>
+/// <param name="AspectRatio">The desired aspect ratio (e.g., "1:1", "16:9", "9:16").</param>
+/// <param name="Quality">The desired image quality; defaults to high quality when <see langword="null"/>.</param>
+/// <param name="SessionId">Optional session identifier for associating the request with a user session.</param>
 public record ImageGenerationRequest(string UserId, string Path, string SceneId, string Prompt, string AspectRatio, GeneratedImageQuality? Quality = null, string? SessionId = null);

--- a/agency/OpenAI/GptService.Image.cs
+++ b/agency/OpenAI/GptService.Image.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+
+using OpenAI.Images;
+
+using ShareInvest.Agency.Models;
+
+using System.ClientModel;
+
+#pragma warning disable OPENAI001
+
+namespace ShareInvest.Agency.OpenAI;
+
+public partial class GptService
+{
+    /// <summary>
+    /// Generates an image via the OpenAI Images API based on the provided request and returns the result as <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to cast the image bytes to (e.g., <see cref="BinaryData"/>).</typeparam>
+    /// <param name="request">Parameters describing the image to generate, including prompt, aspect ratio, and quality.</param>
+    /// <param name="cancellationToken">Token to cancel the asynchronous operation.</param>
+    /// <returns>The generated image bytes cast to <typeparamref name="T"/>, or <see langword="null"/> if the cast fails.</returns>
+    /// <exception cref="ImageGenerationModerationException">Thrown when OpenAI's safety system rejects the request.</exception>
+    public async Task<T?> GenerateImageAsync<T>(ImageGenerationRequest request, CancellationToken cancellationToken = default) where T : class
+    {
+        var size = MapSize(request.AspectRatio);
+
+        var imageClient = GetImageClient(imageModel);
+
+        var options = new ImageGenerationOptions
+        {
+            Size = size,
+            Quality = request.Quality ?? GeneratedImageQuality.HighQuality,
+            OutputFileFormat = GeneratedImageFileFormat.Png,
+        };
+        ClientResult<GeneratedImage> result;
+
+        try
+        {
+            result = await imageClient.GenerateImageAsync(request.Prompt, options, cancellationToken);
+
+            return result.Value.ImageBytes as T;
+        }
+        catch (ClientResultException ex) when (ex.Status == 400)
+        {
+            logger.LogWarning(ex, "Image generation blocked: {Message}", ex.Message);
+
+            throw new ImageGenerationModerationException(ex.Message);
+        }
+    }
+
+    static GeneratedImageSize MapSize(string aspectRatio) => aspectRatio switch
+    {
+        "9:16" => GeneratedImageSize.W1024xH1536,
+        "16:9" => GeneratedImageSize.W1536xH1024,
+        _ => GeneratedImageSize.W1024xH1024,
+    };
+}

--- a/agency/OpenAI/GptService.cs
+++ b/agency/OpenAI/GptService.cs
@@ -2,25 +2,33 @@
 
 using OpenAI;
 using OpenAI.Chat;
-using OpenAI.Images;
 
-using ShareInvest.Agency.Models;
-
-using System.ClientModel;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-#pragma warning disable OPENAI001
-
 namespace ShareInvest.Agency.OpenAI;
 
+/// <summary>
+/// Partial class inheriting <see cref="OpenAIClient"/> that provides GPT-based AI services, including title generation and image generation.
+/// </summary>
 public partial class GptService : OpenAIClient
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="GptService"/> with the specified logger and API key.
+    /// </summary>
+    /// <param name="logger">Logger instance for diagnostic output.</param>
+    /// <param name="apiKey">OpenAI API key used to authenticate requests.</param>
     public GptService(ILogger<GptService> logger, string apiKey) : base(apiKey)
     {
         this.logger = logger;
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="GptService"/> with the specified logger, API key, and custom image model name.
+    /// </summary>
+    /// <param name="logger">Logger instance for diagnostic output.</param>
+    /// <param name="apiKey">OpenAI API key used to authenticate requests.</param>
+    /// <param name="imageModel">Name of the OpenAI image model to use for image generation.</param>
     public GptService(ILogger<GptService> logger, string apiKey, string imageModel) : base(apiKey)
     {
         this.logger = logger;
@@ -30,6 +38,12 @@ public partial class GptService : OpenAIClient
     readonly ILogger<GptService> logger;
     readonly string? imageModel;
 
+    /// <summary>
+    /// Generates a short title (50 characters or fewer) summarising the given conversation text using gpt-5-nano.
+    /// </summary>
+    /// <param name="conversationText">The full conversation text to summarise as a title.</param>
+    /// <param name="cancellationToken">Token to cancel the asynchronous operation.</param>
+    /// <returns>A trimmed title string, or <see langword="null"/> if no usable content was returned.</returns>
     public virtual async Task<string?> GenerateTitleAsync(string conversationText, CancellationToken cancellationToken = default)
     {
         var chatClient = GetChatClient("gpt-5-nano");
@@ -81,39 +95,4 @@ public partial class GptService : OpenAIClient
 
         return reader.ReadToEnd();
     });
-
-    public async Task<T?> GenerateImageAsync<T>(ImageGenerationRequest request, CancellationToken cancellationToken = default) where T : class
-    {
-        var size = MapSize(request.AspectRatio);
-
-        var imageClient = GetImageClient(imageModel);
-
-        var options = new ImageGenerationOptions
-        {
-            Size = size,
-            Quality = request.Quality ?? GeneratedImageQuality.HighQuality,
-            OutputFileFormat = GeneratedImageFileFormat.Png,
-        };
-        ClientResult<GeneratedImage> result;
-
-        try
-        {
-            result = await imageClient.GenerateImageAsync(request.Prompt, options, cancellationToken);
-
-            return result.Value.ImageBytes as T;
-        }
-        catch (ClientResultException ex) when (ex.Status == 400)
-        {
-            logger.LogWarning(ex, "Image generation blocked: {Message}", ex.Message);
-
-            throw new ImageGenerationModerationException(ex.Message);
-        }
-    }
-
-    static GeneratedImageSize MapSize(string aspectRatio) => aspectRatio switch
-    {
-        "9:16" => GeneratedImageSize.W1024xH1536,
-        "16:9" => GeneratedImageSize.W1536xH1024,
-        _ => GeneratedImageSize.W1024xH1024,
-    };
 }


### PR DESCRIPTION
## Summary
- Fill all empty XML `<summary>`, `<param>`, `<returns>`, `<typeparam>` tags across Agency library
- **IAgency.cs** — interface summary
- **GptService.cs** — class, constructors, GenerateTitleAsync
- **GptService.Image.cs** — GenerateImageAsync<T> (new file)
- **ImageGenerationRequest.cs** — record and all 7 params
- **ImageGenerationModerationException.cs** — constructors

## Test plan
- [ ] `dotnet build` succeeds
- [ ] XML doc generation produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)