### PR TITLE
fix: deny requests on DNS resolution failure in SSRF check (#39)

### DIFF
--- a/agency.tests/WebToolsSecurityTests.cs
+++ b/agency.tests/WebToolsSecurityTests.cs
@@ -33,5 +33,20 @@ public class WebToolsSecurityTests : IDisposable
         tools.Dispose(); // Must not throw
     }
 
+    /// <summary>
+    /// Verifies that a hostname which cannot be resolved via DNS is blocked rather than
+    /// allowed through. This guards against DNS rebinding and resolution-failure SSRF bypasses.
+    /// Before the fix, a catch block returned false (allow); it must now return true (block).
+    /// </summary>
+    [Theory]
+    [InlineData("http://this-hostname-does-not-exist.invalid/path")]
+    [InlineData("https://unresolvable-ssrf-test-host.example.invalid/")]
+    public async Task FetchAsync_BlocksUnresolvableHostname(string url)
+    {
+        // An unresolvable hostname must be treated as private/blocked, not allowed through.
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _webTools.FetchAsync(url, TestContext.Current.CancellationToken));
+    }
+
     public void Dispose() => _webTools.Dispose();
 }

--- a/agency/WebTools.cs
+++ b/agency/WebTools.cs
@@ -273,7 +273,9 @@ public sealed partial class WebTools : ISearchProvider, IDisposable
         }
         catch
         {
-            // DNS resolution failure — allow request to proceed and let HttpClient handle the error
+            // DNS resolution failure — treat as private/blocked for safety.
+            // If DNS can't resolve, we shouldn't allow the request to proceed unchecked.
+            return true;
         }
 
         return false;


### PR DESCRIPTION
## Summary
- Change `IsPrivateHostAsync` to return `true` (block) on DNS resolution failure instead of `false` (allow)
- This prevents SSRF bypass via DNS rebinding or resolution failures where an attacker-controlled host temporarily fails DNS, then resolves to a private IP after the check
- Add `FetchAsync_BlocksUnresolvableHostname` tests verifying `.invalid` TLD hostnames are blocked, not allowed through

Fixes #39 (SSRF mitigation gap)

## Test plan
- [ ] `dotnet test` passes (new tests: `FetchAsync_BlocksUnresolvableHostname` x2)
- [ ] Verify unresolvable hostnames are blocked (`http://this-hostname-does-not-exist.invalid/path`)
- [ ] Verify valid public URLs still work (existing tests cover this)
- [ ] Pre-existing `EmbeddedResourceTests` failures are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)