### PR TITLE
fix(E-16): implement IDisposable on GptService

### DIFF
--- a/agency.tests/GptServiceDisposeTests.cs
+++ b/agency.tests/GptServiceDisposeTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+
+using NSubstitute;
+
+using ShareInvest.Agency.OpenAI;
+
+namespace ShareInvest.Agency.Tests;
+
+public class GptServiceDisposeTests
+{
+    static ILogger<GptService> MockLogger() => Substitute.For<ILogger<GptService>>();
+
+    [Fact]
+    public void Dispose_2ParamCtor_DoesNotThrow()
+    {
+        var service = new GptService(MockLogger(), "test-key");
+        service.Dispose(); // Must not throw
+    }
+
+    [Fact]
+    public void Dispose_3ParamCtor_DoesNotThrow()
+    {
+        var service = new GptService(MockLogger(), "test-key", "dall-e-3");
+        service.Dispose(); // Must not throw
+    }
+
+    [Fact]
+    public void Dispose_4ParamCtor_DoesNotThrow()
+    {
+        var service = new GptService(MockLogger(), "test-key", "dall-e-3", null);
+        service.Dispose(); // Must not throw
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var service = new GptService(MockLogger(), "test-key");
+        service.Dispose();
+        service.Dispose(); // WebTools.Dispose is idempotent via HttpClient
+    }
+}

--- a/agency/OpenAI/GptService.cs
+++ b/agency/OpenAI/GptService.cs
@@ -13,7 +13,7 @@ namespace ShareInvest.Agency.OpenAI;
 /// <summary>
 /// Partial class inheriting <see cref="OpenAIClient"/> that provides GPT-based AI services, including title generation and image generation.
 /// </summary>
-public partial class GptService : OpenAIClient
+public partial class GptService : OpenAIClient, IDisposable
 {
     /// <summary>
     /// Initializes a new instance of <see cref="GptService"/> with the specified logger and API key.
@@ -23,6 +23,7 @@ public partial class GptService : OpenAIClient
     public GptService(ILogger<GptService> logger, string apiKey) : base(apiKey)
     {
         this.logger = logger;
+        webTools = new WebTools();
     }
 
     /// <summary>
@@ -35,6 +36,7 @@ public partial class GptService : OpenAIClient
     {
         this.logger = logger;
         this.imageModel = imageModel;
+        webTools = new WebTools();
     }
 
     /// <summary>
@@ -55,7 +57,7 @@ public partial class GptService : OpenAIClient
 
     readonly ILogger<GptService> logger;
     readonly string? imageModel;
-    readonly WebTools webTools = new();
+    readonly WebTools webTools;
 
     /// <summary>
     /// Generates a short title (50 characters or fewer) summarising the given conversation text using gpt-5-nano.
@@ -133,6 +135,12 @@ public partial class GptService : OpenAIClient
             logger.LogWarning("Title repair attempt also returned empty result");
 
         return repairedTitle;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        webTools.Dispose();
     }
 
     static string? CleanTitleResponse(string raw)


### PR DESCRIPTION
## Summary
- Implement `IDisposable` on `GptService` to call `webTools.Dispose()` on teardown
- Fix field initializer leak: 4-param constructor was creating and abandoning a `WebTools` instance
- Add 4 unit tests covering all constructor paths and double-dispose safety

## Audit Reference
Closes launch readiness finding E-16 (CRITICAL): `GptService` lacks `IDisposable` — WebTools and HttpClient socket leak

## Test plan
- [x] `GptServiceDisposeTests` — 4 tests pass
- [ ] Verify no regression in existing tests (6 pre-existing EmbeddedResourceTests failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)