### PR TITLE
fix(S-07): move Exa API key from query string to header

### DIFF
--- a/agency.tests/WebToolsSecurityTests.cs
+++ b/agency.tests/WebToolsSecurityTests.cs
@@ -48,5 +48,51 @@ public class WebToolsSecurityTests : IDisposable
             _webTools.FetchAsync(url, TestContext.Current.CancellationToken));
     }
 
+    /// <summary>
+    /// S-07: Exa API key must never appear in the endpoint URL query string.
+    /// The key must be transmitted only via the x-api-key request header.
+    /// </summary>
+    [Fact]
+    public void WebTools_ExaApiKey_NotExposedInEndpointUrl()
+    {
+        // Use reflection to retrieve the private _exaEndpoint and _exaApiKey fields.
+        var type = typeof(WebTools);
+        var endpointField = type.GetField("_exaEndpoint",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var keyField = type.GetField("_exaApiKey",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        const string testKey = "test-secret-key-12345";
+        using var tools = new WebTools(testKey);
+
+        var endpoint = (Uri?)endpointField!.GetValue(tools);
+        var storedKey = (string?)keyField!.GetValue(tools);
+
+        // The endpoint must not contain the API key in the URL (no query string leakage).
+        Assert.NotNull(endpoint);
+        Assert.DoesNotContain(testKey, endpoint.ToString());
+        Assert.Null(endpoint.Query.Length > 0 ? endpoint.Query : null);
+
+        // The key must be stored for header injection, not discarded.
+        Assert.Equal(testKey, storedKey);
+    }
+
+    /// <summary>
+    /// S-07: When no API key is provided, the endpoint URL must have no query string.
+    /// </summary>
+    [Fact]
+    public void WebTools_NoApiKey_EndpointHasNoQueryString()
+    {
+        var type = typeof(WebTools);
+        var endpointField = type.GetField("_exaEndpoint",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        using var tools = new WebTools();
+        var endpoint = (Uri?)endpointField!.GetValue(tools);
+
+        Assert.NotNull(endpoint);
+        Assert.True(string.IsNullOrEmpty(endpoint.Query), "Endpoint must have no query string when no API key is provided.");
+    }
+
     public void Dispose() => _webTools.Dispose();
 }

--- a/agency/WebTools.cs
+++ b/agency/WebTools.cs
@@ -18,6 +18,7 @@ public sealed partial class WebTools : ISearchProvider, IDisposable
     readonly HttpClient _httpClient;
     readonly HttpClient _fetchClient;
     readonly Uri _exaEndpoint;
+    readonly string? _exaApiKey;
 
     const int MaxRedirects = 5;
 
@@ -25,9 +26,9 @@ public sealed partial class WebTools : ISearchProvider, IDisposable
     /// Initializes a new <see cref="WebTools"/> instance.
     /// </summary>
     /// <param name="exaApiKey">
-    /// Optional Exa API key. When provided, requests are authenticated via
-    /// <c>?exaApiKey={key}</c> query parameter. When <see langword="null"/>,
-    /// requests are sent without authentication (matches P1 OpenCode behavior).
+    /// Optional Exa API key. When provided, requests are authenticated via the
+    /// <c>x-api-key</c> HTTP header. When <see langword="null"/>, requests are
+    /// sent without authentication (matches P1 OpenCode behavior).
     /// </param>
     public WebTools(string? exaApiKey = null)
     {
@@ -51,9 +52,8 @@ public sealed partial class WebTools : ISearchProvider, IDisposable
         _fetchClient.DefaultRequestHeaders.UserAgent.ParseAdd(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
 
-        _exaEndpoint = string.IsNullOrEmpty(exaApiKey)
-            ? new Uri("https://mcp.exa.ai/mcp")
-            : new Uri($"https://mcp.exa.ai/mcp?exaApiKey={Uri.EscapeDataString(exaApiKey)}");
+        _exaEndpoint = new Uri("https://mcp.exa.ai/mcp");
+        _exaApiKey = string.IsNullOrEmpty(exaApiKey) ? null : exaApiKey;
     }
 
     /// <summary>
@@ -100,6 +100,9 @@ public sealed partial class WebTools : ISearchProvider, IDisposable
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        if (_exaApiKey is not null)
+            request.Headers.TryAddWithoutValidation("x-api-key", _exaApiKey);
 
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();


### PR DESCRIPTION
## Summary
- Move Exa API key from URL query parameter to `x-api-key` HTTP header
- Store key in `_exaApiKey` field, inject via `TryAddWithoutValidation` on each request
- Add 2 tests verifying key is never exposed in endpoint URL

## Audit Reference
Closes launch readiness finding S-07 (CRITICAL): Exa API key exposed in URL query string

## Test plan
- [x] `WebTools_ExaApiKey_NotExposedInEndpointUrl` — key absent from URI, present in field
- [x] `WebTools_NoApiKey_EndpointHasNoQueryString` — clean URL baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)