### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.7.0</Version>
+		<Version>0.8.0</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>


### PR DESCRIPTION
## Summary
- Bumps ShareInvest.Agency to 0.8.0 for NuGet publication
- Includes security/stability fixes merged after 0.7.0: #43, #44, #45, #47

## Test plan
- [x] Existing CI tests pass
- [ ] NuGet publish + P5 consumption verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)