### PR TITLE
fix(E-19): pin test csproj dependency versions and add missing explicit refs

### DIFF
--- a/agency.tests/Agency.Tests.csproj
+++ b/agency.tests/Agency.Tests.csproj
@@ -7,10 +7,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageReference Include="xunit.v3" Version="*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="*" />
-    <PackageReference Include="NSubstitute" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\agency\Agency.csproj" />


### PR DESCRIPTION
## Summary

- Replace wildcard `*` version constraints with exact resolutions for all four test packages.
- Add explicit `PackageReference` for `Microsoft.Extensions.Logging.Abstractions 10.0.5` and `OpenAI 2.10.0` which are used directly in test files but were only arriving transitively, causing `CS0234`/`CS0012` build failures on clean restores.

Pinned versions (resolved from current lockfile):
| Package | Version |
|---------|---------|
| Microsoft.Extensions.Logging.Abstractions | 10.0.5 |
| Microsoft.NET.Test.Sdk | 18.4.0 |
| NSubstitute | 5.3.0 |
| OpenAI | 2.10.0 |
| xunit.runner.visualstudio | 3.1.5 |
| xunit.v3 | 3.2.2 |

## Test plan

- [x] `dotnet test -c Release` — 187 tests pass (6 pre-existing EmbeddedResource failures unrelated to this change)
- [x] Build succeeds with no CS0234/CS0012 errors

Closes #52