### PR TITLE
fix(E-20): log FallbackSearchProvider primary failures instead of swallowing silently

### DIFF
--- a/agency.tests/FallbackSearchProviderTests.cs
+++ b/agency.tests/FallbackSearchProviderTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -11,11 +13,12 @@ public class FallbackSearchProviderTests
 {
     readonly ISearchProvider _primary = Substitute.For<ISearchProvider>();
     readonly ISearchProvider _secondary = Substitute.For<ISearchProvider>();
+    readonly ILogger<FallbackSearchProvider> _logger = Substitute.For<ILogger<FallbackSearchProvider>>();
     readonly FallbackSearchProvider _sut;
 
     public FallbackSearchProviderTests()
     {
-        _sut = new FallbackSearchProvider(_primary, _secondary);
+        _sut = new FallbackSearchProvider(_primary, _secondary, _logger);
     }
 
     // ─── Primary succeeds ─────────────────────────────────────────────────────
@@ -204,5 +207,49 @@ public class FallbackSearchProviderTests
 
         await _primary.Received(1)
                       .SearchAsync("q", 8, Arg.Any<CancellationToken>());
+    }
+
+    // ─── Logging behavior ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SearchAsync_PrimaryThrows_LogsWarning()
+    {
+        var exception = new HttpRequestException("network error");
+        _primary.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(exception);
+
+        _secondary.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                  .Returns("fallback");
+
+        await _sut.SearchAsync("query", ct: TestContext.Current.CancellationToken);
+
+        // Logger.Log is called via the ILogger extension method; verify at least one call was made
+        _logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            exception,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task SearchAsync_CancellationRequested_DoesNotLog()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _primary.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _sut.SearchAsync("query", ct: cts.Token));
+
+        // OperationCanceledException must NOT be logged — it propagates directly
+        _logger.DidNotReceive().Log(
+            Arg.Any<LogLevel>(),
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<OperationCanceledException>(),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 }

--- a/agency/FallbackSearchProvider.cs
+++ b/agency/FallbackSearchProvider.cs
@@ -1,12 +1,19 @@
+using Microsoft.Extensions.Logging;
+
 namespace ShareInvest.Agency;
 
 /// <summary>
 /// Chains a primary and secondary <see cref="ISearchProvider"/>.
-/// If the primary search throws any exception the secondary is tried instead.
+/// If the primary search throws any non-cancellation exception the secondary is tried instead,
+/// and the failure is logged as a warning so operational issues remain visible.
 /// </summary>
 /// <param name="primary">The preferred search provider.</param>
 /// <param name="secondary">The fallback search provider used when <paramref name="primary"/> fails.</param>
-public class FallbackSearchProvider(ISearchProvider primary, ISearchProvider secondary) : ISearchProvider
+/// <param name="logger">Logger for recording primary provider failures.</param>
+public class FallbackSearchProvider(
+    ISearchProvider primary,
+    ISearchProvider secondary,
+    ILogger<FallbackSearchProvider> logger) : ISearchProvider
 {
     /// <inheritdoc />
     public async Task<string> SearchAsync(string query, int numResults = 8, CancellationToken ct = default)
@@ -16,8 +23,11 @@ public class FallbackSearchProvider(ISearchProvider primary, ISearchProvider sec
             return await primary.SearchAsync(query, numResults, ct);
         }
         catch (OperationCanceledException) { throw; }
-        catch
+        catch (Exception ex)
         {
+            logger.LogWarning(ex, "Primary search provider {Provider} failed; falling back to secondary",
+                primary.GetType().Name);
+
             return await secondary.SearchAsync(query, numResults, ct);
         }
     }


### PR DESCRIPTION
## Summary

- Add `ILogger<FallbackSearchProvider>` via constructor DI (breaking change to constructor signature — callers must pass logger).
- Replace bare `catch { }` with `catch (Exception ex)` that emits `LogWarning` with the provider name and exception before falling back to secondary.
- `OperationCanceledException` continues to propagate immediately without logging.

## Test plan

- [x] Existing 12 FallbackSearchProvider tests pass unchanged.
- [x] New test: primary throws → `LogLevel.Warning` is recorded with the exception.
- [x] New test: cancellation propagates → no log call.
- [x] `dotnet test -c Release` — 189 tests pass (EmbeddedResource pre-existing failures excluded).

Closes #49