### PR TITLE
fix(P-07): enforce hard cap including truncation marker

### DIFF
--- a/agency.tests/FetchResultPromptTextTests.cs
+++ b/agency.tests/FetchResultPromptTextTests.cs
@@ -65,38 +65,48 @@ public class FetchResultPromptTextTests
 
     // ─── Truncation at MaxToolResultChars ─────────────────────────────────────
 
+    private const string TruncationMarker = "\n[truncated]";
+
+    // Mirrors the production truncation in GptService.Research.cs.
+    // Keep this in sync with that implementation until the logic is
+    // extracted into a shared helper (tracked as follow-up to PR #57).
+    private static string Truncate(string promptText)
+    {
+        if (promptText.Length <= MaxToolResultChars)
+        {
+            return promptText;
+        }
+        var sliceLength = MaxToolResultChars - TruncationMarker.Length;
+        return promptText[..sliceLength] + TruncationMarker;
+    }
+
     [Fact]
     public void ToPromptText_ShortResult_IsNotTruncated()
     {
         var result = MakeFetchResult(new string('x', 100));
 
         var raw = result.ToPromptText();
-        var toolResult = raw.Length > MaxToolResultChars
-            ? raw[..MaxToolResultChars] + "\n[truncated]"
-            : raw;
+        var toolResult = Truncate(raw);
 
         Assert.DoesNotContain("[truncated]", toolResult);
         Assert.Equal(raw, toolResult);
     }
 
     [Fact]
-    public void ToPromptText_LongResult_IsTruncatedAtMaxChars()
+    public void ToPromptText_LongResult_IsTruncatedAtHardCap()
     {
-        // Build a result whose ToPromptText output exceeds MaxToolResultChars
         var result = MakeFetchResult(new string('x', MaxToolResultChars));
 
         var raw = result.ToPromptText();
-
-        // raw includes header lines + mainText, so it will exceed MaxToolResultChars
         Assert.True(raw.Length > MaxToolResultChars,
-            "Test pre-condition: raw output must exceed the cap for this test to be meaningful");
+            "Test pre-condition: raw output must exceed the cap");
 
-        var toolResult = raw.Length > MaxToolResultChars
-            ? raw[..MaxToolResultChars] + "\n[truncated]"
-            : raw;
+        var toolResult = Truncate(raw);
 
-        Assert.EndsWith("\n[truncated]", toolResult);
-        Assert.Equal(MaxToolResultChars + "\n[truncated]".Length, toolResult.Length);
+        Assert.EndsWith(TruncationMarker, toolResult);
+        // Hard cap: final string length must never exceed MaxToolResultChars,
+        // including the truncation marker — previously off by marker.Length.
+        Assert.Equal(MaxToolResultChars, toolResult.Length);
     }
 
     [Fact]
@@ -118,12 +128,11 @@ public class FetchResultPromptTextTests
         Assert.True(raw.Length > MaxToolResultChars,
             "Test pre-condition: raw output must exceed the cap");
 
-        var toolResult = raw.Length > MaxToolResultChars
-            ? raw[..MaxToolResultChars] + "\n[truncated]"
-            : raw;
+        var toolResult = Truncate(raw);
 
-        Assert.True(toolResult.Length <= MaxToolResultChars + "\n[truncated]".Length);
-        Assert.EndsWith("\n[truncated]", toolResult);
+        Assert.True(toolResult.Length <= MaxToolResultChars,
+            "Hard cap must include marker length");
+        Assert.EndsWith(TruncationMarker, toolResult);
     }
 
     [Fact]

--- a/agency/OpenAI/GptService.Research.cs
+++ b/agency/OpenAI/GptService.Research.cs
@@ -199,9 +199,16 @@ public partial class GptService
                                 }
                                 var fetchResult = await webTools.FetchAsync(fetchUrl, cancellationToken);
                                 var promptText = fetchResult.ToPromptText();
-                                toolResult2 = promptText.Length > MaxToolResultChars
-                                    ? promptText[..MaxToolResultChars] + "\n[truncated]"
-                                    : promptText;
+                                if (promptText.Length > MaxToolResultChars)
+                                {
+                                    const string TruncationMarker = "\n[truncated]";
+                                    var sliceLength = MaxToolResultChars - TruncationMarker.Length;
+                                    toolResult2 = promptText[..sliceLength] + TruncationMarker;
+                                }
+                                else
+                                {
+                                    toolResult2 = promptText;
+                                }
                                 consecutiveFetchFailures = 0; // fetch success resets budget
                                 break;
 


### PR DESCRIPTION
## Summary
Follow-up to PR #57 addressing Codex review feedback.

The earlier fix sliced to `MaxToolResultChars` (8,000) and then appended `"\n[truncated]"` (12 chars), producing final strings of 8,012 characters — so the cap was never actually enforced. If this cap exists to stay under provider message limits or to protect context budget, oversized fetch results could still overrun the intended bound.

## Changes
- `GptService.Research.cs`: reserve marker length before slicing so `toolResult.Length <= MaxToolResultChars` always.
- `FetchResultPromptTextTests.cs`: replace inline duplicated slice-and-append with a shared `Truncate()` helper; assert the hard cap (previously asserted the wrong length, which is how the bug slipped through).

## Test plan
- [x] 9 existing truncation tests pass with corrected assertions
- [x] Build clean (Release)

## Known follow-up
Codex also noted that `GptServiceImageErrorTests` (from PR #56) exercises a duplicated `MapImageException` helper rather than `GptService.GenerateImageAsync` itself. That's a separate refactor — tracked as a follow-up, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)