### PR TITLE
feat(Intent 027): librarian structured product info extraction

### DIFF
--- a/agency.tests/ExtractProductInfoTests.cs
+++ b/agency.tests/ExtractProductInfoTests.cs
@@ -82,7 +82,9 @@ public class ExtractProductInfoTests
     [Fact]
     public void ProductInfoResult_RecordEquality_Works()
     {
-        // Records must support structural equality so callers can dedupe / cache results.
+        // Records support per-member equality; scalar / reference-type members compare as
+        // expected. See the <remarks> block on ProductInfoResult — array-typed members use
+        // reference equality, so we only assert scalar equality here.
         var a = new ProductInfoResult(
             1,
             new ProductInfoField<string>("Acme", "spec.pdf"),
@@ -97,5 +99,83 @@ public class ExtractProductInfoTests
 
         Assert.Equal(a.ProductName, b.ProductName);
         Assert.Equal(a.SchemaVersion, b.SchemaVersion);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    //  Regression coverage for PR #62 review feedback
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ParseProductInfoResult_IdWithHtmlChars_RoundTripsWithoutFalseNull()
+    {
+        // BLOCKER regression: previously doc.Id was wrapped in <user_input>…</user_input>
+        // before being sent to the model, causing the model's echoed sourceDocument to fail
+        // knownIds.Contains and every field to be nulled out. We now only HTML-escape the id
+        // at prompt-build time (not at parse time) — so if the model correctly echoes the raw
+        // id (including <>& chars), ValidateField must accept it.
+        var rawId = "<weird>&id";
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName":  { "value": "Acme", "sourceDocument": "<weird>&id" },
+              "sourceDocuments": ["<weird>&id"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, [new ProductInfoDocument(rawId, "body")]);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.ProductName);
+        Assert.Equal("Acme", result.ProductName!.Value);
+        Assert.Equal(rawId, result.ProductName.SourceDocument);
+        Assert.NotNull(result.SourceDocuments);
+        Assert.Contains(rawId, result.SourceDocuments!);
+    }
+
+    [Fact]
+    public void ParseProductInfoResult_UnknownSourceDocuments_AreFilteredOut()
+    {
+        // P2 regression: model-returned sourceDocuments must be intersected with the canonical
+        // input id list. Unknown ids get dropped. If the intersection is empty, we fall back
+        // to the known id list so the provenance roster is never empty.
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName": { "value": "Acme", "sourceDocument": "spec.pdf" },
+              "sourceDocuments": ["spec.pdf", "hallucinated.pdf", "<user_input>spec.pdf</user_input>"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json,
+        [
+            new ProductInfoDocument("spec.pdf",   "A"),
+            new ProductInfoDocument("brochure.md","B")
+        ]);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.SourceDocuments);
+        Assert.Equal(["spec.pdf"], result.SourceDocuments);
+    }
+
+    [Fact]
+    public void ParseProductInfoResult_AllUnknownSourceDocuments_FallsBackToKnownIds()
+    {
+        // Fail-safe: if every id the model returned is unknown, we must fall back to the
+        // canonical input list rather than handing callers an empty roster.
+        var json = """
+            {
+              "schemaVersion": 1,
+              "sourceDocuments": ["totally.bogus", "also.bogus"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json,
+        [
+            new ProductInfoDocument("spec.pdf",   "A"),
+            new ProductInfoDocument("brochure.md","B")
+        ]);
+
+        Assert.NotNull(result);
+        Assert.Equal(["spec.pdf", "brochure.md"], result!.SourceDocuments);
     }
 }

--- a/agency.tests/ExtractProductInfoTests.cs
+++ b/agency.tests/ExtractProductInfoTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using ShareInvest.Agency.Models;
+using ShareInvest.Agency.OpenAI;
+
+namespace ShareInvest.Agency.Tests;
+
+/// <summary>
+/// Integration-flavoured tests for <see cref="GptService.ExtractProductInfoAsync"/> that
+/// exercise argument validation (no network I/O). These tests pin the public contract the
+/// P5 orchestrator depends on so changes that break input invariants are caught before
+/// a PR reaches the orchestrator.
+/// </summary>
+public class ExtractProductInfoTests
+{
+    readonly GptService _sut = new(NullLogger<GptService>.Instance, "test-key");
+
+    [Fact]
+    public async Task ExtractProductInfoAsync_NullDocuments_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            _sut.ExtractProductInfoAsync(null!));
+    }
+
+    [Fact]
+    public async Task ExtractProductInfoAsync_EmptyDocuments_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.ExtractProductInfoAsync([]));
+    }
+
+    [Fact]
+    public async Task ExtractProductInfoAsync_BlankDocumentId_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.ExtractProductInfoAsync([new("   ", "some text")]));
+
+        Assert.Contains("non-empty id", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExtractProductInfoAsync_BlankDocumentText_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.ExtractProductInfoAsync([new("spec.pdf", "   ")]));
+
+        Assert.Contains("empty text", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExtractProductInfoAsync_DuplicateDocumentIds_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.ExtractProductInfoAsync(
+            [
+                new("spec.pdf", "A"),
+                new("spec.pdf", "B")
+            ]));
+
+        Assert.Contains("Duplicate", ex.Message);
+    }
+
+    [Fact]
+    public void DefaultProductInfoSystemPrompt_MentionsEveryRequiredField()
+    {
+        // Pin the no-hallucination contract plus the full field list. If the prompt drifts
+        // and drops a field, this fails loudly instead of silently producing empty results.
+        var prompt = GptService.DefaultProductInfoSystemPrompt;
+
+        Assert.Contains("productName", prompt);
+        Assert.Contains("oneLiner", prompt);
+        Assert.Contains("keyFeatures", prompt);
+        Assert.Contains("detailedSpec", prompt);
+        Assert.Contains("usage", prompt);
+        Assert.Contains("cautions", prompt);
+        Assert.Contains("targetCustomer", prompt);
+        Assert.Contains("sellingPoints", prompt);
+        Assert.Contains("null", prompt);
+        Assert.Contains("sourceDocument", prompt);
+    }
+
+    [Fact]
+    public void ProductInfoResult_RecordEquality_Works()
+    {
+        // Records must support structural equality so callers can dedupe / cache results.
+        var a = new ProductInfoResult(
+            1,
+            new ProductInfoField<string>("Acme", "spec.pdf"),
+            null, null, null, null, null, null, null,
+            ["spec.pdf"]);
+
+        var b = new ProductInfoResult(
+            1,
+            new ProductInfoField<string>("Acme", "spec.pdf"),
+            null, null, null, null, null, null, null,
+            ["spec.pdf"]);
+
+        Assert.Equal(a.ProductName, b.ProductName);
+        Assert.Equal(a.SchemaVersion, b.SchemaVersion);
+    }
+}

--- a/agency.tests/ParseProductInfoResultTests.cs
+++ b/agency.tests/ParseProductInfoResultTests.cs
@@ -1,0 +1,221 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using ShareInvest.Agency.Models;
+using ShareInvest.Agency.OpenAI;
+
+namespace ShareInvest.Agency.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="GptService.ParseProductInfoResult"/> — the JSON parsing +
+/// provenance-validation path exercised without network I/O. Validates the Intent 027
+/// contract: strict JSON, nullable fields, per-field sourceDocument attribution, and
+/// no-hallucination enforcement (unknown document ids are dropped).
+/// </summary>
+public class ParseProductInfoResultTests
+{
+    readonly GptService _sut = new(NullLogger<GptService>.Instance, "test-key");
+
+    static readonly IReadOnlyList<ProductInfoDocument> TwoDocs =
+    [
+        new("spec.pdf", "ignored body"),
+        new("marketing.md", "ignored body")
+    ];
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MinimalValidJson_ReturnsResult()
+    {
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName": { "value": "Acme Widget", "sourceDocument": "spec.pdf" },
+              "sourceDocuments": ["spec.pdf", "marketing.md"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, TwoDocs);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.SchemaVersion);
+        Assert.NotNull(result.ProductName);
+        Assert.Equal("Acme Widget", result.ProductName.Value);
+        Assert.Equal("spec.pdf", result.ProductName.SourceDocument);
+    }
+
+    [Fact]
+    public void Parse_AllFieldsPopulated_MapsCorrectly()
+    {
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName":     { "value": "Acme Widget",                  "sourceDocument": "spec.pdf" },
+              "oneLiner":        { "value": "The quiet revolution.",         "sourceDocument": "marketing.md" },
+              "keyFeatures":     { "value": ["fast","quiet","durable"],      "sourceDocument": "spec.pdf" },
+              "detailedSpec":    { "value": "20cm x 30cm, 1.2kg",             "sourceDocument": "spec.pdf" },
+              "usage":           { "value": "Place on flat surface.",        "sourceDocument": "spec.pdf" },
+              "cautions":        { "value": "Do not immerse.",               "sourceDocument": "spec.pdf" },
+              "targetCustomer":  { "value": "Home office professionals",     "sourceDocument": "marketing.md" },
+              "sellingPoints":   { "value": ["Best-in-class","Award-winning"],"sourceDocument": "marketing.md" },
+              "sourceDocuments": ["spec.pdf","marketing.md"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, TwoDocs);
+
+        Assert.NotNull(result);
+        Assert.Equal("Acme Widget", result.ProductName!.Value);
+        Assert.Equal("marketing.md", result.OneLiner!.SourceDocument);
+        Assert.Equal(3, result.KeyFeatures!.Value.Length);
+        Assert.Contains("quiet", result.KeyFeatures.Value);
+        Assert.Equal("spec.pdf", result.DetailedSpec!.SourceDocument);
+        Assert.Equal("Home office professionals", result.TargetCustomer!.Value);
+        Assert.Equal(2, result.SellingPoints!.Value.Length);
+        Assert.Equal(["spec.pdf", "marketing.md"], result.SourceDocuments);
+    }
+
+    // ─── Null-field / no-hallucination contract ──────────────────────────────
+
+    [Fact]
+    public void Parse_FieldAbsent_ReturnsNullForThatField()
+    {
+        // Only productName is present — every other field must come back null
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName": { "value": "Acme", "sourceDocument": "spec.pdf" },
+              "sourceDocuments": ["spec.pdf"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, [new("spec.pdf", "x")]);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.ProductName);
+        Assert.Null(result.OneLiner);
+        Assert.Null(result.KeyFeatures);
+        Assert.Null(result.DetailedSpec);
+        Assert.Null(result.Usage);
+        Assert.Null(result.Cautions);
+        Assert.Null(result.TargetCustomer);
+        Assert.Null(result.SellingPoints);
+    }
+
+    [Fact]
+    public void Parse_UnknownSourceDocument_DropsField()
+    {
+        // Model cited a document that was never supplied — treat as hallucinated provenance
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName": { "value": "Phantom", "sourceDocument": "ghost.pdf" },
+              "sourceDocuments": ["spec.pdf"]
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, [new("spec.pdf", "x")]);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ProductName);
+    }
+
+    [Fact]
+    public void Parse_BlankSourceDocument_DropsField()
+    {
+        var json = """
+            {
+              "schemaVersion": 1,
+              "productName": { "value": "NoSource", "sourceDocument": "   " }
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, TwoDocs);
+
+        Assert.NotNull(result);
+        Assert.Null(result.ProductName);
+    }
+
+    // ─── Schema normalization ────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MissingSchemaVersion_DefaultsToOne()
+    {
+        var json = """{"productName":{"value":"X","sourceDocument":"spec.pdf"}}""";
+
+        var result = _sut.ParseProductInfoResult(json, [new("spec.pdf", "x")]);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.SchemaVersion);
+    }
+
+    [Fact]
+    public void Parse_MissingSourceDocuments_BackfilledFromInput()
+    {
+        var json = """{"schemaVersion":1}""";
+
+        var result = _sut.ParseProductInfoResult(json, TwoDocs);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.SourceDocuments);
+        Assert.Equal(["spec.pdf", "marketing.md"], result.SourceDocuments);
+    }
+
+    // ─── Markdown fence tolerance ────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_JsonInMarkdownFence_StripsFence()
+    {
+        var json = "```json\n" + """{"schemaVersion":1}""" + "\n```";
+
+        var result = _sut.ParseProductInfoResult(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.SchemaVersion);
+    }
+
+    [Fact]
+    public void Parse_JsonInUnlabelledFence_StripsFence()
+    {
+        var json = "```\n" + """{"schemaVersion":1}""" + "\n```";
+
+        var result = _sut.ParseProductInfoResult(json);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Parse_PascalCaseKeys_ParsesCorrectly()
+    {
+        var json = """
+            {
+              "SchemaVersion": 1,
+              "ProductName": { "Value": "Acme", "SourceDocument": "spec.pdf" }
+            }
+            """;
+
+        var result = _sut.ParseProductInfoResult(json, [new("spec.pdf", "x")]);
+
+        Assert.NotNull(result);
+        Assert.Equal("Acme", result.ProductName!.Value);
+    }
+
+    // ─── Malformed input ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_InvalidJson_ReturnsNull()
+    {
+        Assert.Null(_sut.ParseProductInfoResult("not json"));
+    }
+
+    [Fact]
+    public void Parse_JsonArray_ReturnsNull()
+    {
+        Assert.Null(_sut.ParseProductInfoResult("[1,2,3]"));
+    }
+
+    [Fact]
+    public void Parse_TruncatedJson_ReturnsNull()
+    {
+        Assert.Null(_sut.ParseProductInfoResult("""{"schemaVersion":1,"productName":"""));
+    }
+}

--- a/agency/Models/ProductInfoResult.cs
+++ b/agency/Models/ProductInfoResult.cs
@@ -6,6 +6,16 @@ namespace ShareInvest.Agency.Models;
 /// (no hallucination). Each present field carries provenance to the source document that
 /// supplied the value so callers (e.g., P5) can present attribution to the user.
 /// </summary>
+/// <remarks>
+/// <para><b>Equality semantics:</b> this is a positional <see langword="record"/>, so the
+/// compiler-generated <see cref="object.Equals(object)"/> compares each parameter with its
+/// default equality. The array-typed members (<see cref="KeyFeatures"/>.<c>Value</c>,
+/// <see cref="SellingPoints"/>.<c>Value</c>, and <see cref="SourceDocuments"/>) therefore use
+/// <b>reference equality</b> — two otherwise-identical results built from separate arrays will
+/// NOT compare equal. Callers that need structural equality (e.g., for deduping or caching)
+/// should compare field-by-field using <see cref="System.Linq.Enumerable.SequenceEqual{T}(IEnumerable{T}, IEnumerable{T})"/>
+/// on the array members, or project into a canonical form before comparing.</para>
+/// </remarks>
 /// <param name="SchemaVersion">Schema version for forward compatibility. Current version is 1.</param>
 /// <param name="ProductName">Primary product name. Null if not present in any document.</param>
 /// <param name="OneLiner">Single-sentence pitch or tagline for the product.</param>

--- a/agency/Models/ProductInfoResult.cs
+++ b/agency/Models/ProductInfoResult.cs
@@ -1,0 +1,52 @@
+namespace ShareInvest.Agency.Models;
+
+/// <summary>
+/// Structured product information extracted from one or more source documents by the librarian.
+/// Every field is nullable — an absent field means "not present in any provided document"
+/// (no hallucination). Each present field carries provenance to the source document that
+/// supplied the value so callers (e.g., P5) can present attribution to the user.
+/// </summary>
+/// <param name="SchemaVersion">Schema version for forward compatibility. Current version is 1.</param>
+/// <param name="ProductName">Primary product name. Null if not present in any document.</param>
+/// <param name="OneLiner">Single-sentence pitch or tagline for the product.</param>
+/// <param name="KeyFeatures">Bulleted list of key features / selling points extracted verbatim from the source.</param>
+/// <param name="DetailedSpec">Detailed specification — materials, dimensions, ingredients, technical details, etc.</param>
+/// <param name="Usage">How to use / instructions for use.</param>
+/// <param name="Cautions">Warnings, cautions, contraindications, or safety notes.</param>
+/// <param name="TargetCustomer">Who the product is for (persona, demographic, use case).</param>
+/// <param name="SellingPoints">Marketing-oriented selling points distinct from raw feature bullets.</param>
+/// <param name="SourceDocuments">Identifiers of all documents considered during extraction.</param>
+public record ProductInfoResult(
+    int SchemaVersion,
+    ProductInfoField<string>? ProductName,
+    ProductInfoField<string>? OneLiner,
+    ProductInfoField<string[]>? KeyFeatures,
+    ProductInfoField<string>? DetailedSpec,
+    ProductInfoField<string>? Usage,
+    ProductInfoField<string>? Cautions,
+    ProductInfoField<string>? TargetCustomer,
+    ProductInfoField<string[]>? SellingPoints,
+    string[]? SourceDocuments);
+
+/// <summary>
+/// A single extracted product-info field together with the identifier of the document that
+/// supplied the value. When multiple documents mention the same field, the librarian selects
+/// the most detailed / authoritative value and records which document it came from.
+/// </summary>
+/// <param name="Value">The extracted value. Never null — if the field is not present in any
+/// document, the containing <see cref="ProductInfoResult"/> property is null instead.</param>
+/// <param name="SourceDocument">Identifier of the source document (filename, ID, or URL) that
+/// supplied this value. Allows P5 to render provenance badges next to each field.</param>
+public record ProductInfoField<T>(
+    T Value,
+    string SourceDocument);
+
+/// <summary>
+/// A single input document for product-info extraction.
+/// </summary>
+/// <param name="Id">Stable identifier used as <c>SourceDocument</c> in the output
+/// (e.g., original filename, UUID, or URL). Must be unique within a single call.</param>
+/// <param name="Text">Plain-text body of the document. Pre-processed / OCR'd upstream by P5.</param>
+public record ProductInfoDocument(
+    string Id,
+    string Text);

--- a/agency/OpenAI/GptService.ProductInfo.cs
+++ b/agency/OpenAI/GptService.ProductInfo.cs
@@ -1,0 +1,241 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+using OpenAI.Chat;
+
+using ShareInvest.Agency.Models;
+
+namespace ShareInvest.Agency.OpenAI;
+
+public partial class GptService
+{
+    /// <summary>
+    /// Default system prompt used by <see cref="ExtractProductInfoAsync"/> when the caller does
+    /// not supply one. Encodes the librarian extraction contract:
+    /// <list type="bullet">
+    /// <item>Return strict JSON matching <see cref="ProductInfoResult"/>.</item>
+    /// <item>Every field is optional — return <c>null</c> if not present in any document.</item>
+    /// <item>Never invent or hallucinate data; quote / paraphrase from the source only.</item>
+    /// <item>For each included field, record which document it came from in <c>sourceDocument</c>.</item>
+    /// <item>When multiple documents disagree, pick the most detailed/authoritative and record that source.</item>
+    /// </list>
+    /// </summary>
+    public const string DefaultProductInfoSystemPrompt = """
+        You are a meticulous product-information librarian. You will receive one or more
+        source documents describing a product, each tagged with a document id. Extract the
+        following structured fields into strict JSON:
+
+          - productName         (string)
+          - oneLiner            (string — single-sentence pitch / tagline)
+          - keyFeatures         (string[] — bulleted key features / benefits)
+          - detailedSpec        (string — materials, dimensions, ingredients, tech specs)
+          - usage               (string — how to use / instructions)
+          - cautions            (string — warnings, contraindications, safety notes)
+          - targetCustomer      (string — persona, demographic, use case)
+          - sellingPoints       (string[] — marketing-oriented selling points)
+
+        RULES — follow exactly:
+
+        1. If a field is NOT present in any of the supplied documents, return null for that
+           field. DO NOT invent, infer beyond the text, or hallucinate plausible values.
+        2. Each present field MUST be emitted as an object of the form
+           {"value": <the value>, "sourceDocument": "<document id>"} where <document id>
+           is exactly one of the ids supplied in the input.
+        3. If multiple documents describe the same field, pick the single most detailed or
+           authoritative source and record THAT document's id. Do not merge strings from
+           different documents into one value.
+        4. For list-valued fields (keyFeatures, sellingPoints), the value is an array of
+           strings all drawn from the same chosen sourceDocument.
+        5. Include a top-level "schemaVersion": 1 and
+           "sourceDocuments": [<every input document id>, ...] listing every document
+           you considered (including ones that contributed nothing).
+        6. Respond with JSON ONLY — no prose, no markdown fences, no commentary.
+        """;
+
+    /// <summary>
+    /// Extracts structured product information from one or more source documents.
+    /// Every output field carries provenance (<see cref="ProductInfoField{T}.SourceDocument"/>)
+    /// so the caller can render which document supplied each field. Missing fields return
+    /// <see langword="null"/> rather than hallucinated values.
+    /// </summary>
+    /// <param name="documents">Source documents to extract from. At least one required.</param>
+    /// <param name="systemPrompt">Optional override for the extraction prompt. Defaults to
+    /// <see cref="DefaultProductInfoSystemPrompt"/>.</param>
+    /// <param name="model">Chat model to use.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="onUsage">Optional callback invoked with token usage after the call.</param>
+    /// <returns>Parsed <see cref="ProductInfoResult"/>, or <see langword="null"/> if the model
+    /// produced no valid JSON.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="documents"/> is empty or
+    /// contains a document with a blank id or blank text.</exception>
+    public virtual async Task<ProductInfoResult?> ExtractProductInfoAsync(
+        IReadOnlyList<ProductInfoDocument> documents,
+        string? systemPrompt = null,
+        string model = "gpt-5.4-nano",
+        CancellationToken cancellationToken = default,
+        Action<ApiUsageEvent>? onUsage = null)
+    {
+        ArgumentNullException.ThrowIfNull(documents);
+
+        if (documents.Count == 0)
+            throw new ArgumentException("At least one document is required.", nameof(documents));
+
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var doc in documents)
+        {
+            if (doc is null)
+                throw new ArgumentException("Documents must not be null.", nameof(documents));
+
+            if (string.IsNullOrWhiteSpace(doc.Id))
+                throw new ArgumentException("Every document must have a non-empty id.", nameof(documents));
+
+            if (string.IsNullOrWhiteSpace(doc.Text))
+                throw new ArgumentException($"Document '{doc.Id}' has empty text.", nameof(documents));
+
+            if (!seenIds.Add(doc.Id))
+                throw new ArgumentException($"Duplicate document id '{doc.Id}'.", nameof(documents));
+        }
+
+        var chatClient = GetChatClient(model);
+
+        var options = new ChatCompletionOptions
+        {
+            MaxOutputTokenCount = 4096,
+            Temperature = 0.1f
+        };
+
+        var userContent = new StringBuilder();
+        userContent.AppendLine("Extract product information from the following documents.");
+        userContent.AppendLine("Use each document's id exactly as shown when recording sourceDocument.");
+        userContent.AppendLine();
+
+        foreach (var doc in documents)
+        {
+            userContent.AppendLine($"<document id=\"{PromptSanitizer.EscapeForPrompt(doc.Id)}\">");
+            userContent.AppendLine(PromptSanitizer.EscapeForPrompt(doc.Text));
+            userContent.AppendLine("</document>");
+            userContent.AppendLine();
+        }
+
+        var messages = new ChatMessage[]
+        {
+            ChatMessage.CreateSystemMessage(systemPrompt ?? DefaultProductInfoSystemPrompt),
+            ChatMessage.CreateUserMessage(userContent.ToString())
+        };
+
+        var sw = Stopwatch.StartNew();
+        var result = await chatClient.CompleteChatAsync(messages, options, cancellationToken);
+        sw.Stop();
+
+        var completion = result.Value;
+
+        if (onUsage is not null && completion.Usage is { } usage)
+        {
+            onUsage(new ApiUsageEvent("openai", model, usage.InputTokenCount, usage.OutputTokenCount,
+                "product_info", LatencyMs: (int)sw.ElapsedMilliseconds));
+        }
+
+        var raw = completion.Content.FirstOrDefault()?.Text;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            logger.LogWarning("Product-info extraction returned empty content");
+            return null;
+        }
+
+        return ParseProductInfoResult(raw, documents);
+    }
+
+    /// <summary>
+    /// Parses the raw model output into a <see cref="ProductInfoResult"/>.
+    /// Strips markdown fences, tolerates PascalCase keys, and normalizes the schema version.
+    /// Exposed as <see langword="internal"/> so unit tests can exercise parsing without hitting
+    /// the network.
+    /// </summary>
+    internal ProductInfoResult? ParseProductInfoResult(
+        string raw,
+        IReadOnlyList<ProductInfoDocument>? documents = null)
+    {
+        var json = raw.Trim();
+
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+
+            if (firstNewline >= 0)
+                json = json[(firstNewline + 1)..];
+
+            if (json.EndsWith("```"))
+                json = json[..^3];
+
+            json = json.Trim();
+        }
+
+        ProductInfoResult? result;
+
+        try
+        {
+            result = JsonSerializer.Deserialize<ProductInfoResult>(json, CaseInsensitiveOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to parse product-info result JSON");
+            return null;
+        }
+
+        if (result is null)
+            return null;
+
+        // Normalize schemaVersion: a missing field deserializes to 0 — upgrade to 1.
+        if (result.SchemaVersion == 0)
+            result = result with { SchemaVersion = 1 };
+
+        // If the model omitted sourceDocuments, backfill from the input list so callers
+        // always get the provenance roster.
+        if (result.SourceDocuments is null or { Length: 0 } && documents is { Count: > 0 })
+            result = result with { SourceDocuments = documents.Select(d => d.Id).ToArray() };
+
+        // Validate that every present field cites a known document id, when we have the
+        // input list to check against. Unknown citations are dropped (set to null) rather
+        // than silently kept — this enforces the "no hallucination" rule.
+        if (documents is { Count: > 0 })
+        {
+            var knownIds = new HashSet<string>(documents.Select(d => d.Id), StringComparer.Ordinal);
+
+            result = result with
+            {
+                ProductName = ValidateField(result.ProductName, knownIds),
+                OneLiner = ValidateField(result.OneLiner, knownIds),
+                KeyFeatures = ValidateField(result.KeyFeatures, knownIds),
+                DetailedSpec = ValidateField(result.DetailedSpec, knownIds),
+                Usage = ValidateField(result.Usage, knownIds),
+                Cautions = ValidateField(result.Cautions, knownIds),
+                TargetCustomer = ValidateField(result.TargetCustomer, knownIds),
+                SellingPoints = ValidateField(result.SellingPoints, knownIds)
+            };
+        }
+
+        return result;
+    }
+
+    static ProductInfoField<T>? ValidateField<T>(ProductInfoField<T>? field, HashSet<string> knownIds)
+    {
+        if (field is null)
+            return null;
+
+        if (field.Value is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(field.SourceDocument))
+            return null;
+
+        if (!knownIds.Contains(field.SourceDocument))
+            return null;
+
+        return field;
+    }
+}

--- a/agency/OpenAI/GptService.ProductInfo.cs
+++ b/agency/OpenAI/GptService.ProductInfo.cs
@@ -115,7 +115,10 @@ public partial class GptService
 
         foreach (var doc in documents)
         {
-            userContent.AppendLine($"<document id=\"{PromptSanitizer.EscapeForPrompt(doc.Id)}\">");
+            // Id must round-trip verbatim: model is told to echo it as sourceDocument, and
+            // ValidateField rejects anything not in the canonical id set. Use the lighter
+            // HTML-escape (no <user_input> wrapping) so the raw id survives the round trip.
+            userContent.AppendLine($"<document id=\"{PromptSanitizer.EscapeIdentifierForPrompt(doc.Id)}\">");
             userContent.AppendLine(PromptSanitizer.EscapeForPrompt(doc.Text));
             userContent.AppendLine("</document>");
             userContent.AppendLine();
@@ -194,10 +197,34 @@ public partial class GptService
         if (result.SchemaVersion == 0)
             result = result with { SchemaVersion = 1 };
 
-        // If the model omitted sourceDocuments, backfill from the input list so callers
-        // always get the provenance roster.
-        if (result.SourceDocuments is null or { Length: 0 } && documents is { Count: > 0 })
-            result = result with { SourceDocuments = documents.Select(d => d.Id).ToArray() };
+        // Normalize sourceDocuments against the canonical input list:
+        //   - If the model omitted / emptied the field, backfill from inputs.
+        //   - If the model returned a set, intersect with known inputs to drop any
+        //     hallucinated ids (model sometimes invents or echoes wrapper tags).
+        //   - Fail-safe: if the intersection is empty, fall back to the known id list so
+        //     callers always receive a non-empty provenance roster.
+        if (documents is { Count: > 0 })
+        {
+            var canonicalIds = documents.Select(d => d.Id).ToArray();
+
+            if (result.SourceDocuments is null or { Length: 0 })
+            {
+                result = result with { SourceDocuments = canonicalIds };
+            }
+            else
+            {
+                var knownSet = new HashSet<string>(canonicalIds, StringComparer.Ordinal);
+                var filtered = result.SourceDocuments
+                    .Where(id => !string.IsNullOrWhiteSpace(id) && knownSet.Contains(id))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+
+                result = result with
+                {
+                    SourceDocuments = filtered.Length > 0 ? filtered : canonicalIds
+                };
+            }
+        }
 
         // Validate that every present field cites a known document id, when we have the
         // input list to check against. Unknown citations are dropped (set to null) rather

--- a/agency/OpenAI/PromptSanitizer.cs
+++ b/agency/OpenAI/PromptSanitizer.cs
@@ -60,4 +60,28 @@ internal static partial class PromptSanitizer
 
         return $"{OpenTag}{text}{CloseTag}";
     }
+
+    /// <summary>
+    /// HTML-escapes structural identifiers (e.g., document ids) for safe inclusion in prompt
+    /// markup WITHOUT wrapping in <c>&lt;user_input&gt;</c> tags. Used when the model is
+    /// instructed to echo the id verbatim: wrapping would cause the model to round-trip the
+    /// wrapper tags, breaking downstream id-equality checks.
+    /// </summary>
+    /// <remarks>
+    /// Only replaces the characters that could break the surrounding attribute/element
+    /// context (<c>&lt;</c>, <c>&gt;</c>, <c>&amp;</c>, <c>"</c>). All other characters —
+    /// including the document id's original casing and punctuation — pass through unchanged
+    /// so <c>knownIds.Contains(id)</c> still succeeds on the parsed output.
+    /// </remarks>
+    internal static string EscapeIdentifierForPrompt(string? identifier)
+    {
+        if (string.IsNullOrEmpty(identifier))
+            return string.Empty;
+
+        return identifier
+            .Replace("&",  "&amp;")
+            .Replace("<",  "&lt;")
+            .Replace(">",  "&gt;")
+            .Replace("\"", "&quot;");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `GptService.ExtractProductInfoAsync` — a new librarian task that extracts 8 structured product-info fields (productName, oneLiner, keyFeatures, detailedSpec, usage, cautions, targetCustomer, sellingPoints) from one or more source documents.
- Each field is returned as `{value, sourceDocument}` so P5 can render provenance. Missing fields return `null` — no hallucination.
- Unknown `sourceDocument` citations from the model are dropped during parsing as a defence-in-depth against hallucinated provenance.

## Changes
- `agency/Models/ProductInfoResult.cs` — new record with `ProductInfoField<T>` wrapper + `ProductInfoDocument` input type.
- `agency/OpenAI/GptService.ProductInfo.cs` — new partial with `ExtractProductInfoAsync`, `DefaultProductInfoSystemPrompt`, and `ParseProductInfoResult` (internal — exercised by tests without network I/O).
- Tests: `ParseProductInfoResultTests` (14) + `ExtractProductInfoTests` (7) — **20 new tests, all passing**.

## Test plan
- [x] `dotnet build Mint.slnx` — clean (0 errors).
- [x] `dotnet test --filter ProductInfo|ExtractProductInfo` — **20/20 pass**.
- [x] Full suite: 228 passed / 6 pre-existing failures unrelated to this change (missing embedded `Prompts/*.md` resources — same failures on `main`).
- [ ] P5 integration once this merges and `ShareInvest.Agency` is bumped/published.

## Refs
- Issue: cyberprophet/mint#60
- Intent: Creative-deliverables/page-mint `intents/027-document-upload-product-info.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)