### PR TITLE
feat(studio-mint): P7 4-shot image-edit agent (Intent 031)

### DIFF
--- a/agency.tests/StudioMintTests.cs
+++ b/agency.tests/StudioMintTests.cs
@@ -1,0 +1,278 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Reflection;
+
+using ShareInvest.Agency.Models;
+using ShareInvest.Agency.OpenAI;
+
+namespace ShareInvest.Agency.Tests;
+
+/// <summary>
+/// Unit tests for the Intent 031 StudioMint agent. The OpenAI image-edit call
+/// itself is not exercised (requires a real key + billing); tests focus on the
+/// deterministic contract — shot definitions, prompt composition, embedded
+/// resource loading, error mapping, input validation, and IsComplete aggregation.
+/// </summary>
+public class StudioMintTests
+{
+    // ─── Shot definitions ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void StudioMintShotTypes_HasExactlyFourV1Shots()
+    {
+        Assert.Equal(4, StudioMintShotTypes.All.Count);
+    }
+
+    [Fact]
+    public void StudioMintShotTypes_ShotIdsAreUnique()
+    {
+        var ids = StudioMintShotTypes.All.Select(s => s.Id).ToArray();
+        Assert.Equal(ids.Length, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public void StudioMintShotTypes_IncludesExpectedV1Slots()
+    {
+        var ids = StudioMintShotTypes.All.Select(s => s.Id).ToHashSet();
+        Assert.Contains("hero-front", ids);
+        Assert.Contains("lifestyle", ids);
+        Assert.Contains("detail-macro", ids);
+        Assert.Contains("alt-angle", ids);
+    }
+
+    [Fact]
+    public void StudioMintShotTypes_EveryShotHasNonEmptyLabelAndDirection()
+    {
+        foreach (var shot in StudioMintShotTypes.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(shot.Label));
+            Assert.False(string.IsNullOrWhiteSpace(shot.Direction));
+        }
+    }
+
+    // ─── BuildShotPrompt ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildShotPrompt_WithoutIntent_OmitsAdditionalGuidanceBlock()
+    {
+        var shot = StudioMintShotTypes.All[0];
+
+        var prompt = GptService.BuildShotPrompt("BASE", shot, intentText: null);
+
+        Assert.StartsWith("BASE", prompt);
+        Assert.Contains($"Shot direction — {shot.Label}:", prompt);
+        Assert.Contains(shot.Direction, prompt);
+        Assert.DoesNotContain("Additional guidance", prompt);
+    }
+
+    [Fact]
+    public void BuildShotPrompt_WithIntent_AppendsTrimmedIntentBlock()
+    {
+        var shot = StudioMintShotTypes.All[0];
+
+        var prompt = GptService.BuildShotPrompt("BASE", shot, intentText: "  premium minimalist vibe  ");
+
+        Assert.Contains("Additional guidance from the user:", prompt);
+        Assert.Contains("premium minimalist vibe", prompt);
+        // Trimmed — the leading/trailing whitespace must not bleed into the prompt.
+        Assert.DoesNotContain("\n  premium", prompt);
+    }
+
+    [Fact]
+    public void BuildShotPrompt_WhitespaceOnlyIntent_TreatedAsAbsent()
+    {
+        var shot = StudioMintShotTypes.All[0];
+
+        var prompt = GptService.BuildShotPrompt("BASE", shot, intentText: "   \n\t  ");
+
+        Assert.DoesNotContain("Additional guidance", prompt);
+    }
+
+    [Fact]
+    public void BuildShotPrompt_EachShotProducesDistinctPrompt()
+    {
+        var prompts = StudioMintShotTypes.All
+            .Select(s => GptService.BuildShotPrompt("BASE", s, null))
+            .ToArray();
+        Assert.Equal(prompts.Length, prompts.Distinct().Count());
+    }
+
+    // ─── Embedded base prompt resource ───────────────────────────────────────
+
+    [Fact]
+    public void BasePromptResource_IsEmbeddedAndLoadable()
+    {
+        var assembly = typeof(GptService).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream("ShareInvest.Agency.Prompts.studio-mint-base.md");
+
+        Assert.NotNull(stream);
+        Assert.True(stream!.Length > 0);
+    }
+
+    [Fact]
+    public void BasePromptResource_ContainsStyleInstructions()
+    {
+        var assembly = typeof(GptService).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream("ShareInvest.Agency.Prompts.studio-mint-base.md");
+        using var reader = new StreamReader(stream!);
+
+        var content = reader.ReadToEnd();
+
+        // Sanity: the base prompt must at least mention photography + preservation,
+        // otherwise the shot prompts would not produce on-brief output.
+        Assert.Contains("photograph", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preserve", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Input validation ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateStudioMintAsync_NullRequest_Throws()
+    {
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => svc.GenerateStudioMintAsync(null!));
+    }
+
+    [Fact]
+    public async Task GenerateStudioMintAsync_NullSourceImage_Throws()
+    {
+        var svc = CreateService();
+        var request = new StudioMintRequest("user-1", SourceImage: null!, "product.png");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => svc.GenerateStudioMintAsync(request));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateStudioMintAsync_MissingFileName_Throws(string? fileName)
+    {
+        var svc = CreateService();
+        var request = new StudioMintRequest(
+            "user-1",
+            BinaryData.FromBytes([0x89, 0x50, 0x4E, 0x47]),
+            fileName!);
+
+        // `ThrowIfNullOrWhiteSpace` throws ArgumentNullException for null and
+        // ArgumentException for empty/whitespace — accept either subclass.
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => svc.GenerateStudioMintAsync(request));
+    }
+
+    // ─── Error mapping (replays the catch ladder used in-place) ──────────────
+
+    static StudioMintShot MapShotException(int index, string shotId, ClientResultException ex)
+    {
+        try
+        {
+            throw ex;
+        }
+        catch (ClientResultException e) when (e.Status == 400)
+        {
+            return new StudioMintShot(index, shotId, ImageBytes: null, ErrorReason: "moderation");
+        }
+        catch (ClientResultException e) when (e.Status == 429)
+        {
+            return new StudioMintShot(index, shotId, ImageBytes: null, ErrorReason: "rate_limited");
+        }
+        catch (ClientResultException e) when (e.Status == 401)
+        {
+            throw new UnauthorizedAccessException("auth", e);
+        }
+        catch (Exception)
+        {
+            return new StudioMintShot(index, shotId, ImageBytes: null, ErrorReason: "unexpected");
+        }
+    }
+
+    [Fact]
+    public void ErrorMapping_Http400_ReturnsModerationReason()
+    {
+        var ex = NewClientResultException(400);
+        var result = MapShotException(0, "hero-front", ex);
+        Assert.Null(result.ImageBytes);
+        Assert.Equal("moderation", result.ErrorReason);
+    }
+
+    [Fact]
+    public void ErrorMapping_Http429_ReturnsRateLimitedReason()
+    {
+        var ex = NewClientResultException(429);
+        var result = MapShotException(0, "hero-front", ex);
+        Assert.Null(result.ImageBytes);
+        Assert.Equal("rate_limited", result.ErrorReason);
+    }
+
+    [Fact]
+    public void ErrorMapping_Http401_ThrowsUnauthorized()
+    {
+        var ex = NewClientResultException(401);
+        Assert.Throws<UnauthorizedAccessException>(
+            () => MapShotException(0, "hero-front", ex));
+    }
+
+    [Fact]
+    public void ErrorMapping_OtherStatus_ReturnsUnexpected()
+    {
+        var ex = NewClientResultException(500);
+        var result = MapShotException(0, "hero-front", ex);
+        Assert.Null(result.ImageBytes);
+        Assert.Equal("unexpected", result.ErrorReason);
+    }
+
+    // ─── Result aggregation ───────────────────────────────────────────────────
+
+    [Fact]
+    public void StudioMintResult_IsComplete_TrueWhenEveryShotHasBytes()
+    {
+        var shots = Enumerable.Range(0, 4)
+            .Select(i => new StudioMintShot(i, $"s{i}", BinaryData.FromString("img")))
+            .ToArray();
+
+        var result = new StudioMintResult(shots, IsComplete: shots.All(s => s.ImageBytes is not null));
+        Assert.True(result.IsComplete);
+    }
+
+    [Fact]
+    public void StudioMintResult_IsComplete_FalseWhenAnyShotMissing()
+    {
+        var shots = new StudioMintShot[]
+        {
+            new(0, "a", BinaryData.FromString("img")),
+            new(1, "b", ImageBytes: null, ErrorReason: "moderation"),
+            new(2, "c", BinaryData.FromString("img")),
+            new(3, "d", BinaryData.FromString("img")),
+        };
+
+        var result = new StudioMintResult(shots, IsComplete: shots.All(s => s.ImageBytes is not null));
+        Assert.False(result.IsComplete);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    static GptService CreateService() =>
+        new(new Microsoft.Extensions.Logging.Abstractions.NullLogger<GptService>(), "test-key", "gpt-image-1");
+
+    static ClientResultException NewClientResultException(int status) =>
+        new("err", new FakePipelineResponse(status));
+
+    sealed class FakePipelineResponse(int status) : PipelineResponse
+    {
+        BinaryData? _content;
+        public override int Status { get; } = status;
+        public override string ReasonPhrase => "err";
+        public override Stream? ContentStream { get; set; }
+        public override BinaryData Content => _content ??= BinaryData.FromString("err");
+        public override BinaryData BufferContent(CancellationToken cancellationToken = default) => Content;
+        public override ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(Content);
+        protected override PipelineResponseHeaders HeadersCore => throw new NotSupportedException();
+        public override void Dispose() { }
+    }
+}

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -35,6 +35,7 @@
 		<EmbeddedResource Include="Prompts\title-system.md" />
 		<EmbeddedResource Include="Prompts\visual-dna-system.md" />
 		<EmbeddedResource Include="Prompts\librarian-system.md" />
+		<EmbeddedResource Include="Prompts\studio-mint-base.md" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/agency/Models/StudioMintRequest.cs
+++ b/agency/Models/StudioMintRequest.cs
@@ -1,0 +1,21 @@
+namespace ShareInvest.Agency.Models;
+
+/// <summary>
+/// Parameters for a StudioMint 4-shot generation request (Intent 031).
+/// The agent takes a user-supplied product photo and produces a bundled
+/// set of studio-quality shots that can be dropped into the PageMint
+/// planning asset library.
+/// </summary>
+/// <param name="UserId">The identifier of the user who owns the request.</param>
+/// <param name="SourceImage">Raw PNG/JPEG bytes of the product photo to enrich.</param>
+/// <param name="SourceImageFileName">Filename including extension (e.g., "product.png"). The OpenAI
+/// Images API validates the format from this extension.</param>
+/// <param name="IntentText">Optional free-text guidance — brand mood, target audience, must-preserve
+/// details. Appended to every shot prompt verbatim.</param>
+/// <param name="SessionId">Optional session identifier for correlating the request with a chat session.</param>
+public record StudioMintRequest(
+    string UserId,
+    BinaryData SourceImage,
+    string SourceImageFileName,
+    string? IntentText = null,
+    string? SessionId = null);

--- a/agency/Models/StudioMintResult.cs
+++ b/agency/Models/StudioMintResult.cs
@@ -1,0 +1,26 @@
+namespace ShareInvest.Agency.Models;
+
+/// <summary>
+/// A single shot produced by <see cref="ShareInvest.Agency.OpenAI.GptService.GenerateStudioMintAsync"/>.
+/// </summary>
+/// <param name="Index">Zero-based index within the batch (0..3 for v1's 4-shot bundle).</param>
+/// <param name="ShotType">Stable identifier for the shot style (e.g., "hero-front", "lifestyle",
+/// "detail-macro", "alt-angle"). Consumers persist this to distinguish variants.</param>
+/// <param name="ImageBytes">Generated PNG bytes, or <see langword="null"/> if this slot failed.</param>
+/// <param name="ErrorReason">Non-null when <see cref="ImageBytes"/> is null — short machine-readable
+/// reason (e.g., "moderation", "rate_limited", "timeout", "unexpected").</param>
+public record StudioMintShot(
+    int Index,
+    string ShotType,
+    BinaryData? ImageBytes,
+    string? ErrorReason = null);
+
+/// <summary>
+/// Aggregate result of a StudioMint batch generation call.
+/// </summary>
+/// <param name="Shots">Always 4 entries for v1. Individual entries may have <c>ImageBytes == null</c>
+/// when that shot failed; see <see cref="StudioMintShot.ErrorReason"/>.</param>
+/// <param name="IsComplete"><see langword="true"/> when every shot succeeded.</param>
+public record StudioMintResult(
+    IReadOnlyList<StudioMintShot> Shots,
+    bool IsComplete);

--- a/agency/OpenAI/GptService.StudioMint.cs
+++ b/agency/OpenAI/GptService.StudioMint.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.Logging;
+
+using OpenAI.Images;
+
+using ShareInvest.Agency.Models;
+
+using System.ClientModel;
+using System.Diagnostics;
+using System.Reflection;
+
+#pragma warning disable OPENAI001
+
+namespace ShareInvest.Agency.OpenAI;
+
+public partial class GptService
+{
+    /// <summary>
+    /// Generates a StudioMint 4-shot bundle from a single product image (Intent 031).
+    /// Each shot runs as a parallel OpenAI image-edit call against the configured image model
+    /// (expected to be "gpt-image-1" for v1); the four shots use fixed style variants so
+    /// downstream consumers can persist a stable <see cref="StudioMintShot.ShotType"/> label.
+    /// </summary>
+    /// <remarks>
+    /// Failures on individual shots are captured on the <see cref="StudioMintShot.ErrorReason"/>
+    /// field rather than thrown, so a partial result still surfaces to the caller. The aggregate
+    /// <see cref="StudioMintResult.IsComplete"/> flag indicates whether every shot succeeded.
+    /// </remarks>
+    /// <param name="request">The source image plus optional intent guidance.</param>
+    /// <param name="cancellationToken">Cancels the entire batch.</param>
+    /// <param name="onUsage">Optional usage callback — invoked once per successful shot.</param>
+    public virtual async Task<StudioMintResult> GenerateStudioMintAsync(
+        StudioMintRequest request,
+        CancellationToken cancellationToken = default,
+        Action<ApiUsageEvent>? onUsage = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.SourceImage);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SourceImageFileName);
+
+        var basePrompt = LoadBasePrompt();
+
+        var tasks = StudioMintShotTypes.All.Select((shot, index) =>
+            GenerateSingleShotAsync(request, shot, index,
+                BuildShotPrompt(basePrompt, shot, request.IntentText), onUsage, cancellationToken)).ToArray();
+
+        var shots = await Task.WhenAll(tasks);
+
+        return new StudioMintResult(shots, IsComplete: shots.All(s => s.ImageBytes is not null));
+    }
+
+    async Task<StudioMintShot> GenerateSingleShotAsync(
+        StudioMintRequest request,
+        StudioMintShotDefinition shot,
+        int index,
+        string prompt,
+        Action<ApiUsageEvent>? onUsage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var imageClient = GetImageClient(imageModel);
+
+            var options = new ImageEditOptions
+            {
+                Size = GeneratedImageSize.W1024xH1024,
+                Quality = GeneratedImageQuality.High,
+                OutputFileFormat = GeneratedImageFileFormat.Png,
+                EndUserId = request.UserId
+            };
+
+            using var sourceStream = request.SourceImage.ToStream();
+
+            var sw = Stopwatch.StartNew();
+            ClientResult<GeneratedImageCollection> result = await imageClient.GenerateImageEditsAsync(
+                sourceStream,
+                request.SourceImageFileName,
+                prompt,
+                imageCount: 1,
+                options,
+                cancellationToken);
+            sw.Stop();
+
+            if (onUsage is not null)
+            {
+                var usage = result.Value.Usage;
+                onUsage(new ApiUsageEvent(
+                    "openai",
+                    imageModel ?? "gpt-image-1",
+                    (int)(usage?.InputTokenCount ?? 0),
+                    (int)(usage?.OutputTokenCount ?? 0),
+                    $"studio-mint:{shot.Id}",
+                    LatencyMs: (int)sw.ElapsedMilliseconds));
+            }
+
+            return new StudioMintShot(index, shot.Id, result.Value[0].ImageBytes);
+        }
+        catch (ClientResultException ex) when (ex.Status == 400)
+        {
+            logger.LogWarning(ex, "StudioMint shot {ShotType} blocked by moderation: {Message}", shot.Id, ex.Message);
+
+            return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: "moderation");
+        }
+        catch (ClientResultException ex) when (ex.Status == 401)
+        {
+            logger.LogError(ex, "StudioMint shot {ShotType} authentication failed — check API key", shot.Id);
+
+            throw new UnauthorizedAccessException(
+                "OpenAI image-edit authentication failed. Verify the API key is valid and has image generation permissions.",
+                ex);
+        }
+        catch (ClientResultException ex) when (ex.Status == 429)
+        {
+            logger.LogWarning(ex, "StudioMint shot {ShotType} rate limited", shot.Id);
+
+            return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: "rate_limited");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "StudioMint shot {ShotType} failed unexpectedly", shot.Id);
+
+            return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: "unexpected");
+        }
+    }
+
+    static string LoadBasePrompt()
+    {
+        if (s_cachedBasePrompt is not null)
+        {
+            return s_cachedBasePrompt;
+        }
+
+        var assembly = typeof(GptService).Assembly;
+        using var stream = assembly.GetManifestResourceStream(BasePromptResourceName)
+            ?? throw new InvalidOperationException($"Embedded resource '{BasePromptResourceName}' not found.");
+        using var reader = new StreamReader(stream);
+
+        return s_cachedBasePrompt = reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Composes the full prompt sent to the OpenAI image-edit endpoint for one shot.
+    /// Extracted to a pure helper so deterministic prompt-shape tests don't need to
+    /// mock the entire OpenAI client.
+    /// </summary>
+    internal static string BuildShotPrompt(string basePrompt, StudioMintShotDefinition shot, string? intentText)
+    {
+        var intentSuffix = string.IsNullOrWhiteSpace(intentText)
+            ? string.Empty
+            : $"\n\nAdditional guidance from the user:\n{intentText.Trim()}";
+
+        return $"{basePrompt}\n\nShot direction — {shot.Label}:\n{shot.Direction}{intentSuffix}";
+    }
+
+    const string BasePromptResourceName = "ShareInvest.Agency.Prompts.studio-mint-base.md";
+    static string? s_cachedBasePrompt;
+}
+
+/// <summary>
+/// One of the four StudioMint v1 shot slots. Kept as a private record so the specific
+/// prompts remain internal implementation detail — consumers only see the <see cref="Id"/>.
+/// </summary>
+internal sealed record StudioMintShotDefinition(string Id, string Label, string Direction);
+
+internal static class StudioMintShotTypes
+{
+    public static readonly IReadOnlyList<StudioMintShotDefinition> All =
+    [
+        new(
+            Id: "hero-front",
+            Label: "Hero front",
+            Direction: "Centered hero composition. Product faces the camera head-on, filling roughly 60% of the frame. Seamless neutral studio background (soft light gray or off-white). Balanced key + fill lighting with subtle reflections on the product's surface. This is the primary marketing shot."),
+        new(
+            Id: "lifestyle",
+            Label: "Lifestyle context",
+            Direction: "Place the product in a natural in-use context that implies how a target customer would interact with it — a clean desk, kitchen counter, bag, or relevant environment. Ambient daylight-style lighting. Supporting props may appear softly out of focus, but the product remains the clear subject and stays in sharp focus."),
+        new(
+            Id: "detail-macro",
+            Label: "Detail macro",
+            Direction: "Tight macro shot emphasising surface texture, finish, and build quality. Fill the frame with the product's most distinctive feature (e.g., seam, material, logo as-is on the product, control, grip). Shallow depth of field, precise focus on the texture, directional side lighting to reveal contour."),
+        new(
+            Id: "alt-angle",
+            Label: "Alternate angle",
+            Direction: "Three-quarter or top-down alternate angle that complements the hero shot. Reveal a side or detail the hero view cannot show. Same neutral studio background and lighting treatment as the hero shot so the two read as a paired set.")
+    ];
+}

--- a/agency/Prompts/studio-mint-base.md
+++ b/agency/Prompts/studio-mint-base.md
@@ -1,0 +1,18 @@
+You are producing studio-quality product photography for an e-commerce
+landing page. Preserve the product exactly as shown in the source image:
+do not alter its shape, proportions, color, branding, or surface finish.
+Output must read as a professional commercial photograph, not an
+illustration or stylised rendering.
+
+Global style rules:
+
+- Real-world photography aesthetic. Sharp focus on the product. Clean,
+  purposeful composition with intentional negative space.
+- Premium studio lighting: soft key light, controlled fill, subtle
+  reflections consistent with the product's material. Avoid harsh
+  top-down flash or uneven color casts.
+- Neutral color grade. No over-saturation. Background should complement
+  (not compete with) the product.
+- Never add text, watermarks, logos that are not already on the product,
+  humans' faces, or speech bubbles.
+- Output must be a single image with the product as the clear subject.


### PR DESCRIPTION
## Summary

First step of the sequential P7 → P5 → P6 rollout of [Intent 031 — StudioMint](https://github.com/Creative-deliverables/page-mint/blob/main/intents/031-studio-mint-package.md).

New agent in ShareInvest.Agency that takes a product photo and produces a bundled set of four studio-quality shots via the OpenAI image-edit endpoint (\`gpt-image-1\` for v1). Each shot runs as a parallel API call sharing a base style prompt so a single partial failure does not drop the entire batch; per-shot errors are reported on \`StudioMintShot.ErrorReason\` and the aggregate \`StudioMintResult.IsComplete\` flag signals all-or-nothing completion.

### Public surface

| File | Purpose |
|------|---------|
| \`Models/StudioMintRequest.cs\` | UserId, SourceImage (BinaryData), filename, optional intent, optional sessionId |
| \`Models/StudioMintResult.cs\` | \`StudioMintShot\` (index, shotType, bytes \| error) + aggregate |
| \`OpenAI/GptService.StudioMint.cs\` | \`virtual GenerateStudioMintAsync(...)\` |
| \`Prompts/studio-mint-base.md\` | Embedded shared style guidance |

### v1 shot types (fixed, single bundled style per Intent 031 scope)

| Id | Purpose |
|----|---------|
| \`hero-front\` | Centered hero on neutral studio background |
| \`lifestyle\` | In-use context with supporting props |
| \`detail-macro\` | Macro on distinctive feature / surface |
| \`alt-angle\` | 3/4 or top-down angle complementing hero |

### Error handling

- HTTP 400 → per-shot \`ErrorReason = \"moderation\"\`, batch continues
- HTTP 429 → per-shot \`ErrorReason = \"rate_limited\"\`, batch continues
- HTTP 401 → propagates \`UnauthorizedAccessException\` (auth failure is batch-level, not per-shot)
- Any other exception → per-shot \`ErrorReason = \"unexpected\"\`, logged

## Test plan

- [x] 21 new cases in \`StudioMintTests.cs\`: shot-type contract, prompt composition (with/without intent, whitespace-only, distinctness), embedded-resource loading, input validation, error-status mapping, \`IsComplete\` aggregation.
- [x] Full suite: **454/454 green** (up from 433).
- [x] Build succeeds: 0 warnings, 0 errors.
- [ ] Live upstream integration: deferred to P5 PR (next step of rollout).

## Out of scope (for this PR)

- Real image-edit API call (requires live OpenAI key + billing). Covered at the P5 boundary.
- Customer-visible shot-type toggles. Intent 031 scope is one bundled style for v1.
- P5 job endpoints, P6 UI — subsequent PRs.

## Notes

- NuGet version unchanged (\`0.9.1\`). P5 \`Models.csproj\` pins this version; this PR adds new public types only, no breaking change.
- Embedded resource registered in \`Agency.csproj\`; existing \`EmbeddedResourceTests\` pattern followed.
- cyberprophet/mint main requires 2 approvals — this PR will need a manual approve to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)