### PR TITLE
chore(P7): bump ShareInvest.Agency 0.9.1 → 0.10.0

### DIFF
--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.9.1</Version>
+		<Version>0.10.0</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>


### PR DESCRIPTION
## Summary
- Bump `Agency.csproj` `<Version>` 0.9.1 → 0.10.0 so a NuGet package containing the Intent 031 StudioMint API can be published
- Unblocks P5 Release build (`StudioMintShot` / `StudioMintResult` / `StudioMintRequest` are not in 0.9.1 on nuget.org, causing CS0246 in `StudioMintJobWorker.cs`)

## Test plan
- [x] `dotnet build -c Release` → succeeds, produces `ShareInvest.Agency.0.10.0.nupkg`
- [x] `dotnet test -c Release` → 454 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)