### PR TITLE
chore(P7): bump ShareInvest.Agency 0.10.0 → 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.11.0] — 2026-04-16
+
+### Added
+- **`AnalyzeReferenceLinkAsync` on `GptService`** (Intent 041 Phase A) — dedicated subagent that extracts layout pattern, copy tone, color palette, typography, messaging angles, and raw summary from a reference web page's HTML. Uses `gpt-5.4` with tool-calling + JSON schema validation and 3-attempt retry. ([#70])
+- **`ReferenceLinkAnalysis` DTO** (Intent 041 Phase A) — structured result record (`LayoutPattern`, `CopyTone`, `ColorPalette`, `TypographyStyle`, `MessagingAngles`, `RawSummary`). ([#70])
+- **`ReferenceLinkContext`** — input context (target language + optional product name) for the reference-link analyzer.
+
+### Changed
+- Package version bumped `0.10.0 → 0.11.0`.
+
+---
+
 ## [0.10.0] — 2026-04-13
 
 ### Added

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.10.0</Version>
+		<Version>0.11.0</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>


### PR DESCRIPTION
## Summary

Publishes the ReferenceLinkAnalyst subagent (Intent 041 Phase A, #70) to nuget.org so P5 can consume it for the end-to-end reference-link flow (Phase B, hermes-engine#84).

Package `ShareInvest.Agency.0.11.0` was pushed to nuget.org at 2026-04-16 before opening this PR, to unblock downstream P5 work while the PR reviews.

## Changes in 0.11.0 (from #70, already merged)

- `AnalyzeReferenceLinkAsync` on `GptService` — dedicated reference-page analyzer using `gpt-5.4` with tool-calling + JSON schema validation, 3-attempt retry.
- `ReferenceLinkAnalysis` DTO — `LayoutPattern`, `CopyTone`, `ColorPalette`, `TypographyStyle`, `MessagingAngles`, `RawSummary`.
- `ReferenceLinkContext` — target language + optional product name.

## Test plan

- [x] `dotnet pack -c Release -o ./nupkg` → `ShareInvest.Agency.0.11.0.nupkg` produced cleanly.
- [x] `dotnet nuget push` succeeded against nuget.org.
- [x] Package is visible at https://www.nuget.org/packages/ShareInvest.Agency/0.11.0 (propagation ~1–2 min).
- [ ] P5 Models.csproj bump PR follow-up references 0.11.0.

## Next

- P5: bump `Models/Models.csproj` to `0.11.0` (separate PR).
- P5: `HandleReferenceLinkAnalysisRequestAsync` + `ReferenceLinkAnalyses` migration (separate PR).
- P8: `analyze_reference_link` tool + session-loader query + planner prompt line (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)