### PR TITLE
fix: unify pricing to token-based calculation for all models

### DIFF
--- a/agency.tests/ModelPricingTableTests.cs
+++ b/agency.tests/ModelPricingTableTests.cs
@@ -1,0 +1,113 @@
+using ShareInvest.Agency.Models;
+
+namespace Agency.Tests;
+
+public class ModelPricingTableTests
+{
+    [Theory]
+    [InlineData("openai", "gpt-5.4", 1_000_000, 1_000_000, 2.50 + 15.00)]
+    [InlineData("openai", "gpt-5.4-nano", 1_000_000, 1_000_000, 0.20 + 1.25)]
+    [InlineData("openai", "gpt-5-nano", 1_000_000, 1_000_000, 0.05 + 0.40)]
+    [InlineData("anthropic", "claude-haiku-4-5-20251001", 1_000_000, 1_000_000, 1.00 + 5.00)]
+    public void EstimateCost_TextModels_MatchesProviderRates(string provider, string model, int input, int output, double expected)
+    {
+        var cost = ModelPricingTable.EstimateCost(provider, model, input, output);
+
+        Assert.NotNull(cost);
+        Assert.Equal((decimal)expected, cost.Value);
+    }
+
+    [Theory]
+    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 10.00 + 40.00)]
+    [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 8.00 + 32.00)]
+    [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 2.50 + 8.00)]
+    public void EstimateCost_ImageModels_UsesImageModalityTokenRates(string provider, string model, int input, int output, double expected)
+    {
+        var cost = ModelPricingTable.EstimateCost(provider, model, input, output);
+
+        Assert.NotNull(cost);
+        Assert.Equal((decimal)expected, cost.Value);
+    }
+
+    /// <summary>
+    /// Verify that token-based image pricing produces values consistent with
+    /// OpenAI's published per-image prices (which are precomputed from tokens).
+    /// high quality 1024×1024 ≈ 4,160 output tokens → 4160/1M × $40 = $0.1664.
+    /// </summary>
+    [Fact]
+    public void EstimateCost_ImageGeneration_MatchesPerImagePrice()
+    {
+        // high quality 1024×1024: ~4,160 output tokens, ~200 text input tokens
+        var cost = ModelPricingTable.EstimateCost("openai", "gpt-image-1",
+            inputTokens: 200, outputTokens: 4_160);
+
+        Assert.NotNull(cost);
+
+        // Output: 4160/1M × $40 = $0.16640
+        // Input:  200/1M × $10 = $0.00200
+        // Total: $0.16840
+        Assert.Equal(0.16840m, cost.Value);
+    }
+
+    [Fact]
+    public void EstimateCost_UnknownModel_ReturnsNull()
+    {
+        var cost = ModelPricingTable.EstimateCost("openai", "unknown-model", 1000, 1000);
+
+        Assert.Null(cost);
+    }
+
+    [Fact]
+    public void EstimateCost_CaseInsensitive()
+    {
+        var lower = ModelPricingTable.EstimateCost("openai", "gpt-image-1", 1000, 1000);
+        var upper = ModelPricingTable.EstimateCost("OpenAI", "GPT-IMAGE-1", 1000, 1000);
+
+        Assert.NotNull(lower);
+        Assert.NotNull(upper);
+        Assert.Equal(lower, upper);
+    }
+
+    [Fact]
+    public void EstimateCost_ApiUsageEvent_RoutesCorrectly()
+    {
+        var textEvent = new ApiUsageEvent("openai", "gpt-5.4", 5000, 8000, "blueprint");
+        var imageEvent = new ApiUsageEvent("openai", "gpt-image-1", 200, 4160, "image",
+            ImageQuality: "high", ImageSize: "1024x1024");
+
+        var textCost = ModelPricingTable.EstimateCost(textEvent);
+        var imageCost = ModelPricingTable.EstimateCost(imageEvent);
+
+        Assert.NotNull(textCost);
+        Assert.NotNull(imageCost);
+
+        // Text: 5000/1M × 2.50 + 8000/1M × 15.00 = 0.0125 + 0.12 = 0.1325
+        Assert.Equal(0.1325m, textCost.Value);
+
+        // Image: 200/1M × 10.00 + 4160/1M × 40.00 = 0.002 + 0.1664 = 0.1684
+        Assert.Equal(0.1684m, imageCost.Value);
+    }
+
+    [Fact]
+    public void EstimateCost_Anthropic_IncludesCacheTokens()
+    {
+        var cost = ModelPricingTable.EstimateCost("anthropic", "claude-haiku-4-5-20251001",
+            inputTokens: 1_000_000, outputTokens: 500_000,
+            cacheWriteTokens: 200_000, cacheReadTokens: 800_000);
+
+        Assert.NotNull(cost);
+
+        // Input:      1M/1M × 1.00 = 1.00
+        // Output:   500K/1M × 5.00 = 2.50
+        // CacheWrite: 200K/1M × 1.25 = 0.25
+        // CacheRead:  800K/1M × 0.10 = 0.08
+        // Total: 3.83
+        Assert.Equal(3.83m, cost.Value);
+    }
+
+    [Fact]
+    public void PricingVersion_IsThree()
+    {
+        Assert.Equal(3, ModelPricingTable.PricingVersion);
+    }
+}

--- a/agency.tests/ModelPricingTableTests.cs
+++ b/agency.tests/ModelPricingTableTests.cs
@@ -106,6 +106,29 @@ public class ModelPricingTableTests
     }
 
     [Fact]
+    public void EstimateCost_ImageModel_ZeroOutputTokens_ReturnsNull()
+    {
+        // When OpenAI SDK returns null Usage, tokens default to 0.
+        // Fail-closed: return null (unknown cost) instead of $0.
+        var usage = new ApiUsageEvent("openai", "gpt-image-1", 0, 0, "image",
+            ImageQuality: "high", ImageSize: "1024x1024");
+
+        Assert.Null(ModelPricingTable.EstimateCost(usage));
+    }
+
+    [Fact]
+    public void EstimateCost_TextModel_ZeroTokens_ReturnsZero()
+    {
+        // Text models with 0 tokens should still return 0 (not null) — this is valid.
+        var usage = new ApiUsageEvent("openai", "gpt-5.4", 0, 0, "blueprint");
+
+        var cost = ModelPricingTable.EstimateCost(usage);
+
+        Assert.NotNull(cost);
+        Assert.Equal(0m, cost.Value);
+    }
+
+    [Fact]
     public void PricingVersion_IsThree()
     {
         Assert.Equal(3, ModelPricingTable.PricingVersion);

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -7,56 +7,44 @@ namespace ShareInvest.Agency.Models;
 /// <param name="CacheReadUsdPer1M">Cache read cost per 1M tokens (USD). Zero if not applicable.</param>
 public record ModelPricing(decimal InputUsdPer1M, decimal OutputUsdPer1M, decimal CacheWriteUsdPer1M = 0, decimal CacheReadUsdPer1M = 0);
 
-/// <summary>Per-image pricing keyed by (quality, size) for image generation models.</summary>
-/// <param name="CostPerImage">USD cost per generated image.</param>
-public record ImagePricing(decimal CostPerImage);
-
 /// <summary>
 /// Static lookup table of provider+model token prices. Prices are sourced
 /// from each provider's public pricing page and updated manually.
 /// Bump <see cref="PricingVersion"/> when entries change.
+///
+/// Image generation models (gpt-image-*) use the Image modality token rates.
+/// The OpenAI API reports input_tokens and output_tokens for image calls;
+/// output tokens represent the generated image and scale with quality × size
+/// (e.g. high 1024×1024 ≈ 4,160 output tokens).
 /// </summary>
 public static class ModelPricingTable
 {
     /// <summary>Increment when pricing entries are added, removed, or changed.</summary>
-    public const int PricingVersion = 2;
+    public const int PricingVersion = 3;
 
-    /// <summary>Known text-model prices keyed by (provider, model) tuple. Lookups are case-insensitive.</summary>
+    /// <summary>
+    /// Known model prices keyed by (provider, model) tuple. Lookups are case-insensitive.
+    /// Image models use Image modality rates (verified 2026-04-17 against OpenAI pricing page).
+    /// </summary>
     public static readonly IReadOnlyDictionary<(string Provider, string Model), ModelPricing> Prices =
         new Dictionary<(string, string), ModelPricing>(ProviderModelComparer.Instance)
         {
-            [("openai", "gpt-5.4")] = new(2.50m, 15.00m),
+            // --- Text models ---
+            [("openai", "gpt-5.4")]      = new(2.50m, 15.00m),
             [("openai", "gpt-5.4-nano")] = new(0.20m, 1.25m),
-            [("openai", "gpt-5-nano")] = new(0.05m, 0.40m),
+            [("openai", "gpt-5-nano")]   = new(0.05m, 0.40m),
+
             [("anthropic", "claude-haiku-4-5-20251001")] = new(1.00m, 5.00m, 1.25m, 0.10m),
+
+            // --- Image models (Image modality token rates) ---
+            // Input  = image-input rate (covers both text prompt tokens and source-image tokens)
+            // Output = image-output rate (generated image tokens; count varies by quality × size)
+            [("openai", "gpt-image-1")]      = new(10.00m, 40.00m),
+            [("openai", "gpt-image-1.5")]    = new(8.00m, 32.00m),
+            [("openai", "gpt-image-1-mini")] = new(2.50m, 8.00m),
         }.AsReadOnly();
 
-    /// <summary>Per-image prices keyed by (model, quality, size). Verified 2026-04-17.</summary>
-    public static readonly IReadOnlyDictionary<(string Model, string Quality, string Size), ImagePricing> ImagePrices =
-        new Dictionary<(string, string, string), ImagePricing>(ImageKeyComparer.Instance)
-        {
-        [("gpt-image-1", "low", "1024x1024")] = new(0.011m),
-        [("gpt-image-1", "low", "1024x1536")] = new(0.016m),
-        [("gpt-image-1", "low", "1536x1024")] = new(0.016m),
-        [("gpt-image-1", "medium", "1024x1024")] = new(0.042m),
-        [("gpt-image-1", "medium", "1024x1536")] = new(0.063m),
-        [("gpt-image-1", "medium", "1536x1024")] = new(0.063m),
-        [("gpt-image-1", "high", "1024x1024")] = new(0.167m),
-        [("gpt-image-1", "high", "1024x1536")] = new(0.25m),
-        [("gpt-image-1", "high", "1536x1024")] = new(0.25m),
-
-        [("gpt-image-1.5", "low", "1024x1024")] = new(0.009m),
-        [("gpt-image-1.5", "low", "1024x1536")] = new(0.013m),
-        [("gpt-image-1.5", "low", "1536x1024")] = new(0.013m),
-        [("gpt-image-1.5", "medium", "1024x1024")] = new(0.034m),
-        [("gpt-image-1.5", "medium", "1024x1536")] = new(0.05m),
-        [("gpt-image-1.5", "medium", "1536x1024")] = new(0.05m),
-        [("gpt-image-1.5", "high", "1024x1024")] = new(0.133m),
-        [("gpt-image-1.5", "high", "1024x1536")] = new(0.2m),
-        [("gpt-image-1.5", "high", "1536x1024")] = new(0.2m),
-    }.AsReadOnly();
-
-    /// <summary>Estimates the USD cost for a single text-model API call based on token counts. Returns null for unknown models.</summary>
+    /// <summary>Estimates the USD cost for a single API call based on token counts. Returns null for unknown models.</summary>
     public static decimal? EstimateCost(string provider, string model, int inputTokens, int outputTokens, int? cacheWriteTokens = null, int? cacheReadTokens = null)
     {
         if (!Prices.TryGetValue((provider, model), out var pricing))
@@ -73,27 +61,9 @@ public static class ModelPricingTable
         return cost;
     }
 
-    /// <summary>Estimates the USD cost for a single image generation call. Returns null for unknown model/quality/size combinations.</summary>
-    public static decimal? EstimateImageCost(string model, string? quality, string? size)
-    {
-        quality ??= "high";
-        size ??= "1024x1024";
-
-        return ImagePrices.TryGetValue((model, quality, size), out var pricing)
-            ? pricing.CostPerImage
-            : null;
-    }
-
-    /// <summary>Unified estimator: routes to <see cref="EstimateCost"/> for text models or <see cref="EstimateImageCost"/> for image models based on <see cref="ApiUsageEvent"/>.</summary>
+    /// <summary>Unified estimator: resolves provider+model from <see cref="ApiUsageEvent"/> and delegates to the token-based calculator.</summary>
     public static decimal? EstimateCost(ApiUsageEvent usage)
     {
-        if (usage.ImageQuality is not null || usage.ImageSize is not null)
-            return EstimateImageCost(usage.Model, usage.ImageQuality, usage.ImageSize);
-
-        if (usage.Model.StartsWith("gpt-image", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(usage.Purpose, "image", StringComparison.OrdinalIgnoreCase))
-            return EstimateImageCost(usage.Model, null, null);
-
         return EstimateCost(usage.Provider, usage.Model, usage.InputTokens, usage.OutputTokens);
     }
 
@@ -109,21 +79,5 @@ public static class ModelPricingTable
             HashCode.Combine(
                 StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item1),
                 StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item2));
-    }
-
-    sealed class ImageKeyComparer : IEqualityComparer<(string, string, string)>
-    {
-        public static readonly ImageKeyComparer Instance = new();
-
-        public bool Equals((string, string, string) x, (string, string, string) y) =>
-            StringComparer.OrdinalIgnoreCase.Equals(x.Item1, y.Item1) &&
-            StringComparer.OrdinalIgnoreCase.Equals(x.Item2, y.Item2) &&
-            StringComparer.OrdinalIgnoreCase.Equals(x.Item3, y.Item3);
-
-        public int GetHashCode((string, string, string) obj) =>
-            HashCode.Combine(
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item1),
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item2),
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item3));
     }
 }

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -61,9 +61,16 @@ public static class ModelPricingTable
         return cost;
     }
 
-    /// <summary>Unified estimator: resolves provider+model from <see cref="ApiUsageEvent"/> and delegates to the token-based calculator.</summary>
+    /// <summary>
+    /// Unified estimator: resolves provider+model from <see cref="ApiUsageEvent"/> and delegates to the token-based calculator.
+    /// Returns null (fail-closed) when an image model reports zero output tokens, which indicates the API did not return usage data.
+    /// </summary>
     public static decimal? EstimateCost(ApiUsageEvent usage)
     {
+        if (usage.OutputTokens == 0
+            && usage.Model.StartsWith("gpt-image", StringComparison.OrdinalIgnoreCase))
+            return null;
+
         return EstimateCost(usage.Provider, usage.Model, usage.InputTokens, usage.OutputTokens);
     }
 


### PR DESCRIPTION
## Summary
- Replace per-image lookup (ImagePrices/EstimateImageCost) with token-based pricing for image models
- OpenAI API reports input_tokens/output_tokens for image calls — output tokens scale with quality × size
- Add gpt-image-1, gpt-image-1.5, gpt-image-1-mini to unified Prices dictionary with Image modality rates
- Remove ImagePricing record, ImagePrices, EstimateImageCost, ImageKeyComparer
- Bump PricingVersion 2 → 3
- Add 13 unit tests covering text models, image models, cache tokens, case-insensitivity, and unknown model handling

## Pricing verification (2026-04-17)
| Model | Input (per 1M) | Output (per 1M) | Source |
|-------|---------------|-----------------|--------|
| gpt-image-1 | $10.00 | $40.00 | OpenAI pricing page (Image modality) |
| gpt-image-1.5 | $8.00 | $32.00 | OpenAI pricing page (Image modality) |
| gpt-image-1-mini | $2.50 | $8.00 | OpenAI pricing page (Image modality) |

## Test plan
- [x] 13 new unit tests pass (text models, image models, cache tokens, edge cases)
- [ ] Verify P5 consumer compiles with Agency 0.16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)