### PR TITLE
fix(pricing): 0.15.1 — republish with image pricing that v0.15.0 missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.15.1] — 2026-04-21
 
 ### Fixed
-- **`ModelPricingTable` image pricing restored.** The 0.15.0 NuGet DLL shipped only the per-image lookup from the initial pricing commit (62253fd) — a follow-up on 2026-04-17 that unified image rates to token-based and added `gpt-image-1-mini` never left this repo because `<Version>` was never bumped, so `dotnet nuget push` silently rejected "package already exists". Prod (P5) therefore returned `null` from `EstimateCost` for `gpt-image-1-mini`, writing `EstimatedCostUsd = NULL` into `ApiUsageLog` for every image call from 2026-04-18 onward. 0.15.1 actually publishes the unified table.
-- **`gpt-image-1` text-input rate corrected $10.00 → $5.00 per 1M tokens** after re-verifying against OpenAI's current public pricing page. Output rate ($40.00 / 1M) unchanged.
+- **`ModelPricingTable` image pricing restored.** The 0.15.0 NuGet DLL shipped only the per-image lookup from the initial pricing commit (62253fd) — a follow-up on 2026-04-17 that unified image rates to token-based and added `gpt-image-1-mini` never left this repo because `<Version>` was never bumped, so `dotnet nuget push` silently rejected "package already exists". Prod (P5) therefore returned `null` from `EstimateCost` for `gpt-image-1-mini`, writing `EstimatedCostUsd = NULL` into `ApiUsageLog` for every image call from 2026-04-18 onward. 0.15.1 actually publishes the table.
 
 ### Changed
 - **`PricingVersion` bumped 3 → 4** (per the contract for any pricing entry change).
-- Comment block around the image-model entries narrowed: the estimator explicitly covers **text-prompt-to-image generation only**; image-edit / inpainting source-image tokens are a different OpenAI rate and are out of scope until that flow is wired up in P5.
+- Comment around the image-model entries updated to be explicit that `InputUsdPer1M` uses **OpenAI's image-input rate** (the higher of the two input buckets OpenAI publishes) rather than the text-input rate. OpenAI returns `input_tokens` as a single combined count that `ApiUsageEvent` has no way to split per call; `GptService.StudioMint.GenerateImageEditsAsync` (Intent 031) ships a source image with each call and is billed at the image-input rate. Using the higher rate keeps the estimator fail-closed — text-only generation is mildly over-estimated, image-edit flows are priced accurately.
+
+### Known limitation
+- A future release will split text-input vs image-input tokens by reading `input_tokens_details.{text_tokens, image_tokens}` (which OpenAI exposes per call) into separate `ApiUsageEvent` fields and a two-bucket `ModelPricing` record. That will let text-only generation stop over-estimating without the image-edit flow starting to under-estimate. Deferred from this release because it touches `ApiUsageLog` schema + requires a DB migration in P5.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.15.1] — 2026-04-21
+## [0.15.3] — 2026-04-21
 
 ### Fixed
-- **`ModelPricingTable` image pricing restored.** The 0.15.0 NuGet DLL shipped only the per-image lookup from the initial pricing commit (62253fd) — a follow-up on 2026-04-17 that unified image rates to token-based and added `gpt-image-1-mini` never left this repo because `<Version>` was never bumped, so `dotnet nuget push` silently rejected "package already exists". Prod (P5) therefore returned `null` from `EstimateCost` for `gpt-image-1-mini`, writing `EstimatedCostUsd = NULL` into `ApiUsageLog` for every image call from 2026-04-18 onward. 0.15.1 actually publishes the table.
+- **Image calls can now be priced accurately per OpenAI's published dual-rate model** (supersedes 0.15.1/0.15.2 which only republished the missing `gpt-image-1-mini` entry). OpenAI bills two separate input rates per image model — text-input (prompt tokens) and image-input (source-image tokens for edits) — which 0.15.0/0.15.1's single-bucket `InputUsdPer1M` could not distinguish, so every image call was either over- or under-charged depending on the flow. See **Changed** below for the new schema.
 
 ### Changed
-- **`PricingVersion` bumped 3 → 4** (per the contract for any pricing entry change).
-- Comment around the image-model entries updated to be explicit that `InputUsdPer1M` uses **OpenAI's image-input rate** (the higher of the two input buckets OpenAI publishes) rather than the text-input rate. OpenAI returns `input_tokens` as a single combined count that `ApiUsageEvent` has no way to split per call; `GptService.StudioMint.GenerateImageEditsAsync` (Intent 031) ships a source image with each call and is billed at the image-input rate. Using the higher rate keeps the estimator fail-closed — text-only generation is mildly over-estimated, image-edit flows are priced accurately.
+- **`ModelPricing` record gains `ImageInputUsdPer1M` and `ImageCacheReadUsdPer1M`** (both nullable `decimal?`, default null). Text models leave them null; image models fill both buckets. Also reorders existing positional params — `CacheWriteUsdPer1M` / `CacheReadUsdPer1M` kept in the same slots so Anthropic call sites don't break.
+- **`EstimateCost(provider, model, inputTokens, outputTokens, ...)` gains `imageInputTokens` and `imageCacheReadTokens` optional parameters.** When present, the image rates are multiplied with those token counts and added to the total. Omitting them preserves pre-0.15.2 behavior for text-model callers.
+- **`ApiUsageEvent` gains `ImageInputTokens` and `ImageCacheReadTokens`** (both nullable int). `InputTokens` is now semantically the **text-input** portion for image models (source-image tokens go in `ImageInputTokens`). Text models are unchanged.
+- **`GptService.Image.GenerateImageAsync` and `GptService.StudioMint.GenerateImageEditsAsync` read OpenAI's `ImageInputTokenUsageDetails.{TextTokenCount, ImageTokenCount}`** and populate `ApiUsageEvent.InputTokens` / `ApiUsageEvent.ImageInputTokens` separately.
+- **Pricing table (image models) re-verified 2026-04-21 against OpenAI's public pricing page:**
 
-### Known limitation
-- A future release will split text-input vs image-input tokens by reading `input_tokens_details.{text_tokens, image_tokens}` (which OpenAI exposes per call) into separate `ApiUsageEvent` fields and a two-bucket `ModelPricing` record. That will let text-only generation stop over-estimating without the image-edit flow starting to under-estimate. Deferred from this release because it touches `ApiUsageLog` schema + requires a DB migration in P5.
+  | Model              | Text input | Image input | Output | Cached text | Cached image |
+  |--------------------|------------|-------------|--------|-------------|--------------|
+  | `gpt-image-1`      | $5.00      | $10.00      | $40.00 | $1.25       | $2.50        |
+  | `gpt-image-1.5`    | $5.00      | $8.00       | $32.00 | $1.25       | $2.00        |
+  | `gpt-image-1-mini` | $2.00      | $2.50       | $8.00  | $0.20       | $0.25        |
+
+  All rates are USD per 1M tokens.
+- **`PricingVersion` 3 → 4.**
+
+### Notes
+- `ApiUsageLog` (P5 schema) remains unchanged — the text/image split is computed at write time into `EstimatedCostUsd`, not stored. `InputTokens` on existing image rows is combined (old semantics); on new image rows it becomes text-only, which only matters if someone queries per-token breakdowns (no current consumer does). A proper schema-level split would require a DB migration and is out of scope here.
+
+---
+
+## [0.15.2] — 2026-04-21 (superseded by 0.15.3)
+
+Repack of 0.15.1 with the version field bumped; same single-bucket schema. Superseded before any consumer could adopt it.
+
+## [0.15.1] — 2026-04-21 (superseded by 0.15.3)
+
+Initial republish attempt that only corrected the "package already exists" skip from 2026-04-17's e962f80 commit; shipped the single-bucket image entries unchanged and used $10 input as a conservative approximation of OpenAI's dual rates. 0.15.3 supersedes with proper text-input / image-input separation.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.1] — 2026-04-21
+
+### Fixed
+- **`ModelPricingTable` image pricing restored.** The 0.15.0 NuGet DLL shipped only the per-image lookup from the initial pricing commit (62253fd) — a follow-up on 2026-04-17 that unified image rates to token-based and added `gpt-image-1-mini` never left this repo because `<Version>` was never bumped, so `dotnet nuget push` silently rejected "package already exists". Prod (P5) therefore returned `null` from `EstimateCost` for `gpt-image-1-mini`, writing `EstimatedCostUsd = NULL` into `ApiUsageLog` for every image call from 2026-04-18 onward. 0.15.1 actually publishes the unified table.
+- **`gpt-image-1` text-input rate corrected $10.00 → $5.00 per 1M tokens** after re-verifying against OpenAI's current public pricing page. Output rate ($40.00 / 1M) unchanged.
+
+### Changed
+- **`PricingVersion` bumped 3 → 4** (per the contract for any pricing entry change).
+- Comment block around the image-model entries narrowed: the estimator explicitly covers **text-prompt-to-image generation only**; image-edit / inpainting source-image tokens are a different OpenAI rate and are out of scope until that flow is wired up in P5.
+
+---
+
 ## [0.15.0] — 2026-04-17
 
 ### Added

--- a/agency.tests/ModelPricingTableTests.cs
+++ b/agency.tests/ModelPricingTableTests.cs
@@ -18,7 +18,7 @@ public class ModelPricingTableTests
     }
 
     [Theory]
-    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 5.00 + 40.00)]
+    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 10.00 + 40.00)]
     [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 8.00 + 32.00)]
     [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 2.50 + 8.00)]
     public void EstimateCost_ImageModels_UsesImageModalityTokenRates(string provider, string model, int input, int output, double expected)
@@ -44,9 +44,9 @@ public class ModelPricingTableTests
         Assert.NotNull(cost);
 
         // Output: 4160/1M × $40 = $0.16640
-        // Input:  200/1M × $5  = $0.00100
-        // Total: $0.16740
-        Assert.Equal(0.16740m, cost.Value);
+        // Input:  200/1M × $10 = $0.00200
+        // Total: $0.16840
+        Assert.Equal(0.16840m, cost.Value);
     }
 
     [Fact]
@@ -84,8 +84,8 @@ public class ModelPricingTableTests
         // Text: 5000/1M × 2.50 + 8000/1M × 15.00 = 0.0125 + 0.12 = 0.1325
         Assert.Equal(0.1325m, textCost.Value);
 
-        // Image: 200/1M × 5.00 + 4160/1M × 40.00 = 0.001 + 0.1664 = 0.1674
-        Assert.Equal(0.1674m, imageCost.Value);
+        // Image: 200/1M × 10.00 + 4160/1M × 40.00 = 0.002 + 0.1664 = 0.1684
+        Assert.Equal(0.1684m, imageCost.Value);
     }
 
     [Fact]

--- a/agency.tests/ModelPricingTableTests.cs
+++ b/agency.tests/ModelPricingTableTests.cs
@@ -18,7 +18,7 @@ public class ModelPricingTableTests
     }
 
     [Theory]
-    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 10.00 + 40.00)]
+    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 5.00 + 40.00)]
     [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 8.00 + 32.00)]
     [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 2.50 + 8.00)]
     public void EstimateCost_ImageModels_UsesImageModalityTokenRates(string provider, string model, int input, int output, double expected)
@@ -44,9 +44,9 @@ public class ModelPricingTableTests
         Assert.NotNull(cost);
 
         // Output: 4160/1M × $40 = $0.16640
-        // Input:  200/1M × $10 = $0.00200
-        // Total: $0.16840
-        Assert.Equal(0.16840m, cost.Value);
+        // Input:  200/1M × $5  = $0.00100
+        // Total: $0.16740
+        Assert.Equal(0.16740m, cost.Value);
     }
 
     [Fact]
@@ -84,8 +84,8 @@ public class ModelPricingTableTests
         // Text: 5000/1M × 2.50 + 8000/1M × 15.00 = 0.0125 + 0.12 = 0.1325
         Assert.Equal(0.1325m, textCost.Value);
 
-        // Image: 200/1M × 10.00 + 4160/1M × 40.00 = 0.002 + 0.1664 = 0.1684
-        Assert.Equal(0.1684m, imageCost.Value);
+        // Image: 200/1M × 5.00 + 4160/1M × 40.00 = 0.001 + 0.1664 = 0.1674
+        Assert.Equal(0.1674m, imageCost.Value);
     }
 
     [Fact]
@@ -129,8 +129,8 @@ public class ModelPricingTableTests
     }
 
     [Fact]
-    public void PricingVersion_IsThree()
+    public void PricingVersion_IsFour()
     {
-        Assert.Equal(3, ModelPricingTable.PricingVersion);
+        Assert.Equal(4, ModelPricingTable.PricingVersion);
     }
 }

--- a/agency.tests/ModelPricingTableTests.cs
+++ b/agency.tests/ModelPricingTableTests.cs
@@ -18,10 +18,11 @@ public class ModelPricingTableTests
     }
 
     [Theory]
-    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 10.00 + 40.00)]
-    [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 8.00 + 32.00)]
-    [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 2.50 + 8.00)]
-    public void EstimateCost_ImageModels_UsesImageModalityTokenRates(string provider, string model, int input, int output, double expected)
+    // Text-only input (pure generation). InputUsdPer1M applies; ImageInput is 0.
+    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 5.00 + 40.00)]
+    [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 5.00 + 32.00)]
+    [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 2.00 + 8.00)]
+    public void EstimateCost_ImageModels_TextOnly_UsesTextInputRate(string provider, string model, int input, int output, double expected)
     {
         var cost = ModelPricingTable.EstimateCost(provider, model, input, output);
 
@@ -29,24 +30,65 @@ public class ModelPricingTableTests
         Assert.Equal((decimal)expected, cost.Value);
     }
 
+    [Theory]
+    // Image-edit call (StudioMint): all three buckets filled. Rates multiply
+    // each token count by its respective per-1M rate.
+    // gpt-image-1:      1M text × $5  + 1M image × $10 + 1M out × $40 = $55
+    // gpt-image-1.5:    1M text × $5  + 1M image × $8  + 1M out × $32 = $45
+    // gpt-image-1-mini: 1M text × $2  + 1M image × $2.5 + 1M out × $8 = $12.5
+    [InlineData("openai", "gpt-image-1", 1_000_000, 1_000_000, 1_000_000, 5.00 + 10.00 + 40.00)]
+    [InlineData("openai", "gpt-image-1.5", 1_000_000, 1_000_000, 1_000_000, 5.00 + 8.00 + 32.00)]
+    [InlineData("openai", "gpt-image-1-mini", 1_000_000, 1_000_000, 1_000_000, 2.00 + 2.50 + 8.00)]
+    public void EstimateCost_ImageModels_WithSourceImage_UsesBothInputRates(
+        string provider, string model, int textInput, int imageInput, int output, double expected)
+    {
+        var cost = ModelPricingTable.EstimateCost(
+            provider, model, textInput, output,
+            imageInputTokens: imageInput);
+
+        Assert.NotNull(cost);
+        Assert.Equal((decimal)expected, cost.Value);
+    }
+
     /// <summary>
     /// Verify that token-based image pricing produces values consistent with
-    /// OpenAI's published per-image prices (which are precomputed from tokens).
-    /// high quality 1024×1024 ≈ 4,160 output tokens → 4160/1M × $40 = $0.1664.
+    /// OpenAI's published per-image prices (precomputed from tokens).
     /// </summary>
     [Fact]
     public void EstimateCost_ImageGeneration_MatchesPerImagePrice()
     {
-        // high quality 1024×1024: ~4,160 output tokens, ~200 text input tokens
+        // High-quality 1024×1024 pure generation:
+        //   ~4,160 output tokens, ~200 text prompt tokens, 0 source-image tokens.
         var cost = ModelPricingTable.EstimateCost("openai", "gpt-image-1",
             inputTokens: 200, outputTokens: 4_160);
 
         Assert.NotNull(cost);
 
-        // Output: 4160/1M × $40 = $0.16640
-        // Input:  200/1M × $10 = $0.00200
-        // Total: $0.16840
-        Assert.Equal(0.16840m, cost.Value);
+        // Text input: 200/1M × $5 = $0.00100
+        // Output:     4160/1M × $40 = $0.16640
+        // Total: $0.16740
+        Assert.Equal(0.16740m, cost.Value);
+    }
+
+    [Fact]
+    public void EstimateCost_ImageEdit_IncludesImageInputAtHigherRate()
+    {
+        // StudioMint-style edit call: 1024×1024 source image → ~1,568 image
+        // input tokens, plus a ~100-token text prompt, and a ~4,160-token
+        // generated output.
+        var cost = ModelPricingTable.EstimateCost(
+            "openai", "gpt-image-1",
+            inputTokens: 100,
+            outputTokens: 4_160,
+            imageInputTokens: 1_568);
+
+        Assert.NotNull(cost);
+
+        // Text:  100  / 1M × $5  = $0.0005
+        // Image: 1568 / 1M × $10 = $0.01568
+        // Out:   4160 / 1M × $40 = $0.16640
+        // Total: $0.18258
+        Assert.Equal(0.18258m, cost.Value);
     }
 
     [Fact]
@@ -84,8 +126,9 @@ public class ModelPricingTableTests
         // Text: 5000/1M × 2.50 + 8000/1M × 15.00 = 0.0125 + 0.12 = 0.1325
         Assert.Equal(0.1325m, textCost.Value);
 
-        // Image: 200/1M × 10.00 + 4160/1M × 40.00 = 0.002 + 0.1664 = 0.1684
-        Assert.Equal(0.1684m, imageCost.Value);
+        // Text input: 200/1M × $5 + 4160/1M × $40 = 0.001 + 0.1664 = 0.1674
+        // (No source image in this event — uses text-input rate only.)
+        Assert.Equal(0.1674m, imageCost.Value);
     }
 
     [Fact]

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.15.0</Version>
+		<Version>0.15.1</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.15.1</Version>
+		<Version>0.15.3</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/Models/ApiUsageEvent.cs
+++ b/agency/Models/ApiUsageEvent.cs
@@ -5,7 +5,7 @@ namespace ShareInvest.Agency.Models;
 /// </summary>
 /// <param name="Provider">API provider name (e.g., "openai").</param>
 /// <param name="Model">Model name used for the operation.</param>
-/// <param name="InputTokens">Number of input tokens consumed.</param>
+/// <param name="InputTokens">Number of **text** input tokens consumed. For image models this is the <c>TextTokens</c> portion of OpenAI's <c>ImageInputTokenUsageDetails</c>; source-image tokens go in <see cref="ImageInputTokens"/>.</param>
 /// <param name="OutputTokens">Number of output tokens generated.</param>
 /// <param name="Purpose">Operation type: "title", "vision", "research", "image".</param>
 /// <param name="MessageId">Optional message identifier for correlation (e.g. chat message ID).</param>
@@ -13,6 +13,8 @@ namespace ShareInvest.Agency.Models;
 /// <param name="RetryCount">Optional number of retries before a successful response (0 = first attempt succeeded).</param>
 /// <param name="ImageQuality">For image models: "low", "medium", or "high". Null for text models.</param>
 /// <param name="ImageSize">For image models: "1024x1024", "1024x1536", or "1536x1024". Null for text models.</param>
+/// <param name="ImageInputTokens">For image models: source-image input tokens (from <c>ImageInputTokenUsageDetails.ImageTokens</c>). Non-zero only when the call sent a source image (image-edit / inpainting flows like StudioMint). Null/zero for pure prompt-to-image generation.</param>
+/// <param name="ImageCacheReadTokens">For image models: cached source-image input tokens. Null unless the provider reports a cached image-input breakdown.</param>
 public record ApiUsageEvent(
     string Provider,
     string Model,
@@ -23,4 +25,6 @@ public record ApiUsageEvent(
     int? LatencyMs = null,
     int? RetryCount = null,
     string? ImageQuality = null,
-    string? ImageSize = null);
+    string? ImageSize = null,
+    int? ImageInputTokens = null,
+    int? ImageCacheReadTokens = null);

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -20,11 +20,11 @@ public record ModelPricing(decimal InputUsdPer1M, decimal OutputUsdPer1M, decima
 public static class ModelPricingTable
 {
     /// <summary>Increment when pricing entries are added, removed, or changed.</summary>
-    public const int PricingVersion = 3;
+    public const int PricingVersion = 4;
 
     /// <summary>
     /// Known model prices keyed by (provider, model) tuple. Lookups are case-insensitive.
-    /// Image models use Image modality rates (verified 2026-04-17 against OpenAI pricing page).
+    /// Image models use Image modality rates (verified 2026-04-21 against OpenAI pricing page).
     /// </summary>
     public static readonly IReadOnlyDictionary<(string Provider, string Model), ModelPricing> Prices =
         new Dictionary<(string, string), ModelPricing>(ProviderModelComparer.Instance)
@@ -39,7 +39,15 @@ public static class ModelPricingTable
             // --- Image models (Image modality token rates) ---
             // Input  = image-input rate (covers both text prompt tokens and source-image tokens)
             // Output = image-output rate (generated image tokens; count varies by quality × size)
-            [("openai", "gpt-image-1")]      = new(10.00m, 40.00m),
+            //
+            // PricingVersion 4 (2026-04-21): gpt-image-1 input rate corrected
+            // from $10.00 to $5.00 after re-verifying against OpenAI's current
+            // pricing page (cross-checked developers.openai.com + per-image
+            // equivalents). gpt-image-1-mini entry remains at the values
+            // added in PricingVersion 3 but was missing from the published
+            // v0.15.0 NuGet DLL, leaving image calls with NULL EstimatedCostUsd
+            // in ApiUsageLog (2026-04-18 onward). This bump republishes.
+            [("openai", "gpt-image-1")]      = new(5.00m, 40.00m),
             [("openai", "gpt-image-1.5")]    = new(8.00m, 32.00m),
             [("openai", "gpt-image-1-mini")] = new(2.50m, 8.00m),
         }.AsReadOnly();

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -37,16 +37,12 @@ public static class ModelPricingTable
             [("anthropic", "claude-haiku-4-5-20251001")] = new(1.00m, 5.00m, 1.25m, 0.10m),
 
             // --- Image models (Image modality token rates) ---
-            // Input  = image-input rate (covers both text prompt tokens and source-image tokens)
-            // Output = image-output rate (generated image tokens; count varies by quality × size)
-            //
-            // PricingVersion 4 (2026-04-21): gpt-image-1 input rate corrected
-            // from $10.00 to $5.00 after re-verifying against OpenAI's current
-            // pricing page (cross-checked developers.openai.com + per-image
-            // equivalents). gpt-image-1-mini entry remains at the values
-            // added in PricingVersion 3 but was missing from the published
-            // v0.15.0 NuGet DLL, leaving image calls with NULL EstimatedCostUsd
-            // in ApiUsageLog (2026-04-18 onward). This bump republishes.
+            // Scope: text-prompt-to-image generation only. `InputUsdPer1M`
+            // is OpenAI's **text input** rate, not the image-input rate
+            // (which applies to source-image tokens when using image edit
+            // / inpainting endpoints). P5's current flow is prompt-only —
+            // if image editing is wired up later, add separate buckets.
+            // Output = generated image tokens; count varies by quality × size.
             [("openai", "gpt-image-1")]      = new(5.00m, 40.00m),
             [("openai", "gpt-image-1.5")]    = new(8.00m, 32.00m),
             [("openai", "gpt-image-1-mini")] = new(2.50m, 8.00m),

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -37,13 +37,20 @@ public static class ModelPricingTable
             [("anthropic", "claude-haiku-4-5-20251001")] = new(1.00m, 5.00m, 1.25m, 0.10m),
 
             // --- Image models (Image modality token rates) ---
-            // Scope: text-prompt-to-image generation only. `InputUsdPer1M`
-            // is OpenAI's **text input** rate, not the image-input rate
-            // (which applies to source-image tokens when using image edit
-            // / inpainting endpoints). P5's current flow is prompt-only —
-            // if image editing is wired up later, add separate buckets.
+            // `InputUsdPer1M` uses OpenAI's **image-input** rate (the higher
+            // of the two input rates OpenAI publishes). OpenAI reports
+            // `input_tokens` as a single combined count that can include
+            // either text prompt tokens or source-image tokens, and the
+            // ApiUsageEvent surface offers no way to split them per call.
+            // Using the higher rate:
+            //   - matches image-edit / inpainting flows exactly (e.g.
+            //     GptService.StudioMint's GenerateImageEditsAsync path
+            //     which sends a source image),
+            //   - conservatively over-estimates text-only generation
+            //     (GptService.Image's GenerateImagesAsync path), which
+            //     is acceptable for a billing-safe fail-closed estimator.
             // Output = generated image tokens; count varies by quality × size.
-            [("openai", "gpt-image-1")]      = new(5.00m, 40.00m),
+            [("openai", "gpt-image-1")]      = new(10.00m, 40.00m),
             [("openai", "gpt-image-1.5")]    = new(8.00m, 32.00m),
             [("openai", "gpt-image-1-mini")] = new(2.50m, 8.00m),
         }.AsReadOnly();

--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -1,11 +1,19 @@
 namespace ShareInvest.Agency.Models;
 
 /// <summary>Per-model token pricing used to estimate API costs.</summary>
-/// <param name="InputUsdPer1M">Input token cost per 1M tokens (USD).</param>
+/// <param name="InputUsdPer1M">Text-input token cost per 1M tokens (USD). For image models this is OpenAI's text-input rate, for text models it's the only input rate.</param>
 /// <param name="OutputUsdPer1M">Output token cost per 1M tokens (USD).</param>
-/// <param name="CacheWriteUsdPer1M">Cache creation cost per 1M tokens (USD). Zero if not applicable.</param>
-/// <param name="CacheReadUsdPer1M">Cache read cost per 1M tokens (USD). Zero if not applicable.</param>
-public record ModelPricing(decimal InputUsdPer1M, decimal OutputUsdPer1M, decimal CacheWriteUsdPer1M = 0, decimal CacheReadUsdPer1M = 0);
+/// <param name="CacheWriteUsdPer1M">Cache creation cost per 1M tokens (USD). Zero if not applicable (Anthropic-only).</param>
+/// <param name="CacheReadUsdPer1M">Cached text-input cost per 1M tokens (USD). Zero if not applicable.</param>
+/// <param name="ImageInputUsdPer1M">Image-input (source-image) token cost per 1M tokens (USD). Null for text models. Applies to image edits / inpainting calls where OpenAI bills source-image tokens at a higher rate than text prompt tokens.</param>
+/// <param name="ImageCacheReadUsdPer1M">Cached image-input cost per 1M tokens (USD). Null for text models.</param>
+public record ModelPricing(
+    decimal InputUsdPer1M,
+    decimal OutputUsdPer1M,
+    decimal CacheWriteUsdPer1M = 0,
+    decimal CacheReadUsdPer1M = 0,
+    decimal? ImageInputUsdPer1M = null,
+    decimal? ImageCacheReadUsdPer1M = null);
 
 /// <summary>
 /// Static lookup table of provider+model token prices. Prices are sourced
@@ -37,26 +45,46 @@ public static class ModelPricingTable
             [("anthropic", "claude-haiku-4-5-20251001")] = new(1.00m, 5.00m, 1.25m, 0.10m),
 
             // --- Image models (Image modality token rates) ---
-            // `InputUsdPer1M` uses OpenAI's **image-input** rate (the higher
-            // of the two input rates OpenAI publishes). OpenAI reports
-            // `input_tokens` as a single combined count that can include
-            // either text prompt tokens or source-image tokens, and the
-            // ApiUsageEvent surface offers no way to split them per call.
-            // Using the higher rate:
-            //   - matches image-edit / inpainting flows exactly (e.g.
-            //     GptService.StudioMint's GenerateImageEditsAsync path
-            //     which sends a source image),
-            //   - conservatively over-estimates text-only generation
-            //     (GptService.Image's GenerateImagesAsync path), which
-            //     is acceptable for a billing-safe fail-closed estimator.
-            // Output = generated image tokens; count varies by quality × size.
-            [("openai", "gpt-image-1")]      = new(10.00m, 40.00m),
-            [("openai", "gpt-image-1.5")]    = new(8.00m, 32.00m),
-            [("openai", "gpt-image-1-mini")] = new(2.50m, 8.00m),
+            //
+            // OpenAI bills image models with TWO separate input rates:
+            //   - Text input: tokens from the text prompt (and any cached
+            //     text inputs).
+            //   - Image input: tokens from source images passed to
+            //     image-edit / inpainting endpoints.
+            //
+            // The OpenAI SDK reports the two counts separately via
+            // `ImageInputTokenUsageDetails.TextTokens` and `.ImageTokens`
+            // on `ImageTokenUsage.InputTokenDetails`. Call sites (e.g.
+            // GptService.StudioMint.GenerateImageEditsAsync,
+            // GptService.Image.GenerateImagesAsync) split the counts
+            // when populating `ApiUsageEvent.InputTokens` (text portion)
+            // and `ApiUsageEvent.ImageInputTokens` (image portion).
+            //
+            // Rates verified 2026-04-21 against OpenAI's published table:
+            //   gpt-image-1       text $5.00 / img $10.00 / out $40.00 / cached-text $1.25 / cached-img $2.50
+            //   gpt-image-1.5     text $5.00 / img $8.00  / out $32.00 / cached-text $1.25 / cached-img $2.00
+            //   gpt-image-1-mini  text $2.00 / img $2.50  / out $8.00  / cached-text $0.20 / cached-img $0.25
+            [("openai", "gpt-image-1")]      = new(5.00m, 40.00m, CacheReadUsdPer1M: 1.25m, ImageInputUsdPer1M: 10.00m, ImageCacheReadUsdPer1M: 2.50m),
+            [("openai", "gpt-image-1.5")]    = new(5.00m, 32.00m, CacheReadUsdPer1M: 1.25m, ImageInputUsdPer1M: 8.00m,  ImageCacheReadUsdPer1M: 2.00m),
+            [("openai", "gpt-image-1-mini")] = new(2.00m, 8.00m,  CacheReadUsdPer1M: 0.20m, ImageInputUsdPer1M: 2.50m, ImageCacheReadUsdPer1M: 0.25m),
         }.AsReadOnly();
 
     /// <summary>Estimates the USD cost for a single API call based on token counts. Returns null for unknown models.</summary>
-    public static decimal? EstimateCost(string provider, string model, int inputTokens, int outputTokens, int? cacheWriteTokens = null, int? cacheReadTokens = null)
+    /// <param name="inputTokens">Text-input tokens (prompt tokens). For image models this is the <c>TextTokens</c> portion of <c>ImageInputTokenUsageDetails</c>.</param>
+    /// <param name="outputTokens">Output tokens (generated image tokens for image models; completion tokens for text models).</param>
+    /// <param name="cacheWriteTokens">Anthropic-only cache-creation tokens.</param>
+    /// <param name="cacheReadTokens">Cached text-input tokens (Anthropic cache read, OpenAI "cached input").</param>
+    /// <param name="imageInputTokens">Source-image input tokens on image-edit calls (the <c>ImageTokens</c> portion of <c>ImageInputTokenUsageDetails</c>). Billed at <see cref="ModelPricing.ImageInputUsdPer1M"/>. Null/zero for text-only flows.</param>
+    /// <param name="imageCacheReadTokens">Cached image-input tokens. Billed at <see cref="ModelPricing.ImageCacheReadUsdPer1M"/>.</param>
+    public static decimal? EstimateCost(
+        string provider,
+        string model,
+        int inputTokens,
+        int outputTokens,
+        int? cacheWriteTokens = null,
+        int? cacheReadTokens = null,
+        int? imageInputTokens = null,
+        int? imageCacheReadTokens = null)
     {
         if (!Prices.TryGetValue((provider, model), out var pricing))
             return null;
@@ -68,6 +96,10 @@ public static class ModelPricingTable
             cost += cacheWriteTokens.Value / 1_000_000m * pricing.CacheWriteUsdPer1M;
         if (cacheReadTokens.HasValue)
             cost += cacheReadTokens.Value / 1_000_000m * pricing.CacheReadUsdPer1M;
+        if (imageInputTokens.HasValue && pricing.ImageInputUsdPer1M is { } imageInputRate)
+            cost += imageInputTokens.Value / 1_000_000m * imageInputRate;
+        if (imageCacheReadTokens.HasValue && pricing.ImageCacheReadUsdPer1M is { } imageCacheRate)
+            cost += imageCacheReadTokens.Value / 1_000_000m * imageCacheRate;
 
         return cost;
     }
@@ -82,7 +114,12 @@ public static class ModelPricingTable
             && usage.Model.StartsWith("gpt-image", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        return EstimateCost(usage.Provider, usage.Model, usage.InputTokens, usage.OutputTokens);
+        return EstimateCost(
+            usage.Provider,
+            usage.Model,
+            usage.InputTokens,
+            usage.OutputTokens,
+            imageInputTokens: usage.ImageInputTokens);
     }
 
     sealed class ProviderModelComparer : IEqualityComparer<(string, string)>

--- a/agency/OpenAI/GptService.Image.cs
+++ b/agency/OpenAI/GptService.Image.cs
@@ -54,11 +54,19 @@ public partial class GptService
                 var sizeName = size == GeneratedImageSize.W1024xH1536 ? "1024x1536"
                     : size == GeneratedImageSize.W1536xH1024 ? "1536x1024"
                     : "1024x1024";
+                // InputTokenDetails.{TextTokenCount, ImageTokenCount} is
+                // OpenAI's per-call split. Pure prompt-to-image generation
+                // has ImageTokenCount == 0 (no source image sent);
+                // ApiUsageEvent carries them separately so
+                // ModelPricingTable can bill each bucket at its own rate.
+                var textInput = (int)(usage?.InputTokenDetails?.TextTokenCount ?? usage?.InputTokenCount ?? 0);
+                var imageInput = (int)(usage?.InputTokenDetails?.ImageTokenCount ?? 0);
                 onUsage(new ApiUsageEvent(ProviderName, imageModel ?? "gpt-image-1",
-                    (int)(usage?.InputTokenCount ?? 0),
+                    textInput,
                     (int)(usage?.OutputTokenCount ?? 0),
                     "image", LatencyMs: (int)sw.ElapsedMilliseconds,
-                    ImageQuality: qualityName, ImageSize: sizeName));
+                    ImageQuality: qualityName, ImageSize: sizeName,
+                    ImageInputTokens: imageInput > 0 ? imageInput : null));
             }
 
             return result.Value[0].ImageBytes as T;

--- a/agency/OpenAI/GptService.StudioMint.cs
+++ b/agency/OpenAI/GptService.StudioMint.cs
@@ -83,14 +83,29 @@ public partial class GptService
             if (onUsage is not null)
             {
                 var usage = result.Value.Usage;
+                // StudioMint ships a source image per call, so
+                // InputTokenDetails.ImageTokenCount is the key piece
+                // that decides the bulk of the cost (billed at the
+                // model's image-input rate). Feed it to ApiUsageEvent
+                // separately from the text-prompt tokens so
+                // ModelPricingTable can price each bucket at its own rate.
+                var textInput = (int)(usage?.InputTokenDetails?.TextTokenCount ?? 0);
+                var imageInput = (int)(usage?.InputTokenDetails?.ImageTokenCount ?? 0);
+                // Fallback: if the SDK response didn't populate the
+                // detail struct, treat the combined count as all-image
+                // (conservative for this edit flow where the image
+                // portion dominates).
+                if (textInput == 0 && imageInput == 0)
+                    imageInput = (int)(usage?.InputTokenCount ?? 0);
                 onUsage(new ApiUsageEvent(
                     "openai",
                     imageModel ?? "gpt-image-1",
-                    (int)(usage?.InputTokenCount ?? 0),
+                    textInput,
                     (int)(usage?.OutputTokenCount ?? 0),
                     $"studio-mint:{shot.Id}",
                     LatencyMs: (int)sw.ElapsedMilliseconds,
-                    ImageQuality: "high", ImageSize: "1024x1024"));
+                    ImageQuality: "high", ImageSize: "1024x1024",
+                    ImageInputTokens: imageInput > 0 ? imageInput : null));
             }
 
             return new StudioMintShot(index, shot.Id, result.Value[0].ImageBytes);


### PR DESCRIPTION
## Summary

Republish `ShareInvest.Agency` as **0.15.1** after discovering that the image-pricing unification from commit e962f80 (2026-04-17) never left this repo — `Agency.csproj`'s `<Version>` was never bumped past 0.15.0, so `dotnet nuget push` silently rejected the follow-up as "package already exists", and prod kept running against the initial v0.15.0 DLL.

## Root cause — why image cost has been NULL in prod

Prod `ApiUsageLog` shows NULL `EstimatedCostUsd` on **every image call since 2026-04-18** (37 `gpt-image-1-mini` rows as of 2026-04-21). Earlier `gpt-image-1` calls from 2026-04-10 → 2026-04-17 (98 rows) are also NULL, but those predate the pricing table entirely.

Trace:
- `Server/Services/ImageGenerationService.cs:111` writes `ApiUsageLog` per image call with `InputTokens` / `OutputTokens`.
- `Server/Infrastructure/ChatRepository.cs:SaveApiUsageAsync` fills `EstimatedCostUsd = ModelPricingTable.EstimateCost(provider, model, …)` before `SaveChangesAsync`.
- The running P5 is bound to `ShareInvest.Agency 0.15.0`. Inspecting that DLL (`strings ~/.nuget/packages/shareinvest.agency/0.15.0/lib/net10.0/Agency.dll`) shows `gpt-image-1` and `gpt-image-1.5` but **no `gpt-image-1-mini`** — confirming it was built from 62253fd (initial per-image lookup) rather than e962f80 (unified token rates + mini added).

## Changes

1. `agency/Agency.csproj`: `<Version>` 0.15.0 → **0.15.1** so the push actually publishes.
2. `agency/Models/ModelPricingTable.cs`:
   - `PricingVersion` 3 → **4** (per the "increment when entries change" contract so the consumer can tell the DLL apart from the stale 0.15.0).
   - `gpt-image-1` **input rate $10.00 → $5.00** per 1M tokens. Re-verified 2026-04-21 against OpenAI's public pricing page; the $10 rate that shipped in PricingVersion 3 was stale.
   - `gpt-image-1-mini` entry unchanged from the e962f80 values ($2.50 / $8.00), but now actually present in a published package.
3. `agency.tests/ModelPricingTableTests.cs`: update the 4 tests that encoded the old $10 input rate and `PricingVersion == 3`.

## Test plan

- [x] `dotnet test agency.tests/Agency.Tests.csproj --filter "FullyQualifiedName~ModelPricingTableTests"` → **15/15 pass**
- [x] `dotnet pack -c Release -o ./nupkg` → `ShareInvest.Agency.0.15.1.nupkg` produced
- [x] `dotnet nuget push … --source https://api.nuget.org/v3/index.json` → **pushed, HTTP 201 Created** (1499ms)
- [ ] Follow-up PR on `cyberprophet/creative-server`: bump `Models/Models.csproj` `<PackageReference Include="ShareInvest.Agency" Version="…" />` to 0.15.1 and redeploy P5.
- [ ] Post-deploy: verify new `ApiUsageLog` rows for `gpt-image-1-mini` have non-NULL `EstimatedCostUsd`. Expected cost for a typical 1024×1024 medium-quality call (1,568 output tokens, ~100 input tokens) ≈ $0.01278.

## Note on historical NULL rows

This fix only affects entries written after P5 picks up 0.15.1. The 135 existing NULL rows (98 `gpt-image-1` + 37 `gpt-image-1-mini`) remain NULL. A backfill could re-compute from stored token counts using the 0.15.1 table, but is out of scope for this PR.