### PR TITLE
docs(pricing): add missing <param> tags for provider/model on EstimateCost

### DIFF
--- a/agency/Models/ModelPricingTable.cs
+++ b/agency/Models/ModelPricingTable.cs
@@ -70,6 +70,8 @@ public static class ModelPricingTable
         }.AsReadOnly();
 
     /// <summary>Estimates the USD cost for a single API call based on token counts. Returns null for unknown models.</summary>
+    /// <param name="provider">Provider key in the pricing table (e.g. <c>"openai"</c>, <c>"anthropic"</c>).</param>
+    /// <param name="model">Model key in the pricing table (e.g. <c>"gpt-5.4"</c>, <c>"gpt-image-1"</c>).</param>
     /// <param name="inputTokens">Text-input tokens (prompt tokens). For image models this is the <c>TextTokens</c> portion of <c>ImageInputTokenUsageDetails</c>.</param>
     /// <param name="outputTokens">Output tokens (generated image tokens for image models; completion tokens for text models).</param>
     /// <param name="cacheWriteTokens">Anthropic-only cache-creation tokens.</param>


### PR DESCRIPTION
## Summary
- Adds `<param>` XML doc entries for `provider` and `model` on `ModelPricingTable.EstimateCost`, silencing CS1573 warnings.
- No runtime or API change — documentation only.

## Test plan
- [x] `dotnet build agency/Agency.csproj` → 0 warnings, 0 errors.

## Notes
- Staged for bundling with the next real change; no NuGet publish required on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)