### PR TITLE
fix: add prompt validation to Blueprint/DesignHtml/Storyboard (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.15.4] — 2026-04-22
+
+### Fixed
+- **Prompt-ownership guardrail (ADR-013) applied to three missed entry points.** `GptService.Blueprint*`, `GptService.DesignHtml*`, and `GptService.Storyboard*` now validate their `systemPrompt` parameter with `ArgumentException.ThrowIfNullOrWhiteSpace` at method entry, matching the six peer methods (`GenerateTitleAsync`, `AnalyzeImageAsync`, `ResearchProductAsync`, and Gemini counterparts). Previously null / empty / whitespace prompts would be forwarded to the provider instead of failing fast on the consumer side. Closes #83.
+
+### Tests
+- **`PromptValidationTests.cs`** gains three `[Theory]` methods × 3 `InlineData` cases each covering null / `""` / `"   "` for Blueprint, DesignHtml, Storyboard. Placeholder prompt strings only per ADR-013 — no real prompt content embedded. Suite: 600 → 609 passing.
+
+---
+
 ## [0.15.3] — 2026-04-21
 
 ### Fixed

--- a/agency.tests/PromptValidationTests.cs
+++ b/agency.tests/PromptValidationTests.cs
@@ -84,6 +84,71 @@ public class PromptValidationTests
             () => svc.ResearchProductAsync(badPrompt!, "product info", [], category: null));
     }
 
+    // ─── GptService — GenerateBlueprintAsync ─────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GptService_BlueprintAsync_BlankSystemPrompt_Throws(string? badPrompt)
+    {
+        using var svc = new GptService(NullLogger<GptService>.Instance, "test-key");
+        var context = new BlueprintContext(
+            StoryboardJson: "{}",
+            VisualDna: null,
+            BriefJson: null,
+            Feedback: null);
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => svc.GenerateBlueprintAsync(badPrompt!, context));
+    }
+
+    // ─── GptService — GenerateDesignHtmlAsync ────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GptService_DesignHtmlAsync_BlankSystemPrompt_Throws(string? badPrompt)
+    {
+        using var svc = new GptService(NullLogger<GptService>.Instance, "test-key");
+        var blueprint = new BlueprintResult(
+            PageDesignSystem: new PageDesignSystem("mood", ["#000"], "background", "scale"),
+            VisualBlocks: [],
+            Assumptions: null);
+        var storyboard = new StoryboardResult(Sections: [], CtaText: "cta");
+        var context = new DesignHtmlContext(
+            Blueprint: blueprint,
+            Storyboard: storyboard,
+            Brief: null,
+            Feedback: null);
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => svc.GenerateDesignHtmlAsync(badPrompt!, context));
+    }
+
+    // ─── GptService — GenerateStoryboardAsync ────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GptService_StoryboardAsync_BlankSystemPrompt_Throws(string? badPrompt)
+    {
+        using var svc = new GptService(NullLogger<GptService>.Instance, "test-key");
+        var context = new StoryboardContext(
+            Brief: "{}",
+            MarketContext: "{}",
+            VisualDna: null,
+            TargetLanguage: "en",
+            ForbiddenCliches: null,
+            ProductType: null,
+            Feedback: null);
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => svc.GenerateStoryboardAsync(badPrompt!, context));
+    }
+
     // ─── GeminiProvider — prompt validation ──────────────────────────────────
 
     [Theory]

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.15.3</Version>
+		<Version>0.15.4</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/OpenAI/GptService.Blueprint.cs
+++ b/agency/OpenAI/GptService.Blueprint.cs
@@ -30,6 +30,8 @@ public partial class GptService
         CancellationToken cancellationToken = default,
         Action<ApiUsageEvent>? onUsage = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+
         var chatClient = GetChatClient(model);
 
         var generateBlueprintTool = ChatTool.CreateFunctionTool(

--- a/agency/OpenAI/GptService.DesignHtml.cs
+++ b/agency/OpenAI/GptService.DesignHtml.cs
@@ -29,6 +29,8 @@ public partial class GptService
         CancellationToken cancellationToken = default,
         Action<ApiUsageEvent>? onUsage = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+
         var chatClient = GetChatClient(model);
 
         var renderAndPreviewTool = ChatTool.CreateFunctionTool(

--- a/agency/OpenAI/GptService.Storyboard.cs
+++ b/agency/OpenAI/GptService.Storyboard.cs
@@ -30,6 +30,8 @@ public partial class GptService
         CancellationToken cancellationToken = default,
         Action<ApiUsageEvent>? onUsage = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+
         var chatClient = GetChatClient(model);
 
         var saveStoryboardTool = ChatTool.CreateFunctionTool(


### PR DESCRIPTION
## Summary
Close the ADR-013 regression where 3 of 9 `GptService` entry points accepted null/empty/whitespace system prompts silently. The 2026-04-22 audit flagged `GenerateBlueprintAsync`, `GenerateDesignHtmlAsync`, and `GenerateStoryboardAsync` as the holdouts; all three now guard `systemPrompt` on method entry, matching the style of the 6 already-validating entry points (GenerateTitleAsync, AnalyzeImageAsync, ResearchProductAsync, plus Gemini counterparts).

- `agency/OpenAI/GptService.Blueprint.cs` — guard added at top of `GenerateBlueprintAsync`
- `agency/OpenAI/GptService.DesignHtml.cs` — guard added at top of `GenerateDesignHtmlAsync`
- `agency/OpenAI/GptService.Storyboard.cs` — guard added at top of `GenerateStoryboardAsync`
- `agency.tests/PromptValidationTests.cs` — 3 new `[Theory]` tests (9 cases total) with placeholder prompts only, per ADR-013
- `agency/Agency.csproj` — version bump `0.15.3 -> 0.15.4`

A NuGet publish is **NOT** performed in this PR (policy: P0 ships on request).

## Test Results
- Before: 600 passing / 0 failing
- After: **609 passing / 0 failing** (+9 cases: 3 methods x 3 InlineData each)

Command: `dotnet test agency.tests/Agency.Tests.csproj --nologo -v quiet`

## Policy Compliance
- Tests use placeholder string `"test-prompt"` only — no real prompt content embedded (ADR-013).
- All 3 entry points now reject null/empty/whitespace input with `ArgumentException` (or `ArgumentNullException` subclass via `ThrowIfNullOrWhiteSpace`).

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)