### PR TITLE
docs: remove stale Prompts/title-system.md reference (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var title = await gpt.GenerateTitleAsync(systemPrompt, conversationText, cancell
 // Uses gpt-5-nano by default; titles are capped at 50 characters
 ```
 
-Per [ADR-013](https://github.com/cyberprophet/mint), all agent system prompts are owned by the consumer (page-mint-server) and injected at the call site. This package ships no prompt content — callers must supply `systemPrompt` to every generation method.
+Per [ADR-013](https://github.com/Creative-deliverables/page-mint/blob/main/decisions/013-p7-prompt-ownership-policy.md), all agent system prompts are owned by the consumer (page-mint-server) and injected at the call site. This package ships no prompt content — callers must supply `systemPrompt` to every generation method.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ public class MyService(GptService gpt)
 ## Title Generation
 
 ```csharp
-var title = await gpt.GenerateTitleAsync(conversationText, cancellationToken);
+var title = await gpt.GenerateTitleAsync(systemPrompt, conversationText, cancellationToken: ct);
 // Returns null if generation fails or produces empty content
-// Uses gpt-5-nano with embedded PageMint-tailored system prompt
-// Titles are capped at 50 characters
+// Uses gpt-5-nano by default; titles are capped at 50 characters
 ```
 
-The system prompt is stored as an embedded resource under `Prompts/title-system.md`.
+Per [ADR-013](https://github.com/cyberprophet/mint), all agent system prompts are owned by the consumer (page-mint-server) and injected at the call site. This package ships no prompt content — callers must supply `systemPrompt` to every generation method.
 
 ## Releases
 


### PR DESCRIPTION
## Summary

README.md still referenced an embedded `Prompts/title-system.md` file that was deleted in v0.13.0 when ADR-013 moved all agent system prompts to the consumer (P5 — page-mint-server). The Title Generation example also showed the pre-ADR-013 call signature (no `systemPrompt` parameter).

- Update the `GenerateTitleAsync` code sample to show the current injected-prompt signature.
- Replace the stale `Prompts/title-system.md` sentence with a one-line ADR-013 summary: prompts are owned by the consumer, this package ships no prompt content.
- Docs-only change — no version bump, no CHANGELOG entry.

## Closes

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)