### PR TITLE
[P7] hotfix: drop AnalysisLevel; bump to 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.16.2] — 2026-04-23
+
+### Fixed
+- **Drop `<AnalysisLevel>latest-Recommended</AnalysisLevel>` from `Agency.csproj`.** The broadened analyzer pack (CA1725, CA1848, CA1310, CA1822, CA1859, …) produced ~120 new warnings that P5's CI pipeline promoted to build errors via `dotnet build Vendo.slnx --no-restore -c Release --warnaserror`, breaking the 0.16.1 consumer deploy on run `24864278028`. The intent of 0.16.1 — promote CA2007 to error to prevent regression — is preserved via `.editorconfig` (`dotnet_diagnostic.CA2007.severity = error`), which enables the analyzer on its own without the broader rule set. Verified locally: `dotnet build -c Release --warnaserror` clean with 0.16.2; deliberately removing `.ConfigureAwait(false)` still triggers `CA2007` as error.
+
+### Notes
+- **NuGet consumers: bump `Models.csproj`** in P5 to `Version="0.16.2"` and redeploy. 0.16.1 is retained on nuget.org for history but should not be used because it fails P5's `--warnaserror` CI build.
+
+---
+
 ## [0.16.1] — 2026-04-23
 
 ### Security

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.16.1</Version>
+		<Version>0.16.2</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>
@@ -25,9 +25,11 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageIcon>analytics.png</PackageIcon>
 
-		<!-- Analysis: CA2007 (ConfigureAwait) as error to prevent regression -->
-		<AnalysisLevel>latest-Recommended</AnalysisLevel>
-		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+		<!-- Analysis: CA2007 (ConfigureAwait) is promoted to `error` via
+		     .editorconfig. Do NOT set AnalysisLevel to latest-Recommended here
+		     — that broadens the analyzer pack (CA1725, CA1848, CA1310, CA1822,
+		     CA1859, …) and P5's CI builds with "warnaserror", which turned
+		     every broadened warning into a build failure in 0.16.1. -->
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

0.16.1 shipped with `<AnalysisLevel>latest-Recommended</AnalysisLevel>` in `agency/Agency.csproj` intending to enforce CA2007 at error level. But that flag broadened the analyzer pack to CA1725, CA1848, CA1310, CA1822, CA1859, and ~115 other rules which fired as warnings against pre-existing code.

**Blast radius**: P5's CI builds with `dotnet build Vendo.slnx --no-restore -c Release --warnaserror` — every warning became a build error. The 0.16.1 consumer deploy (Creative-deliverables/creative-server run [`24864278028`](https://github.com/Creative-deliverables/creative-server/actions/runs/24864278028)) failed with 120 errors.

### Fix

Remove `<AnalysisLevel>` entirely. `.editorconfig`'s `dotnet_diagnostic.CA2007.severity = error` is sufficient on its own — it enables CA2007 as an error without pulling in the broader recommended rule set.

## Test plan

- [x] `rm -rf bin obj && dotnet build -c Release --warnaserror` → 0 warning / 0 error
- [x] Sanity: manually removed `.ConfigureAwait(false)` from 2 awaits in `GptService.cs` → build fails with 2 `CA2007` errors, confirming the rule is still enforced
- [x] Restored the 2 awaits, re-verified clean build
- [x] `dotnet test` still green (708 tests)

## Follow-up

Post-merge:
1. `dotnet pack -c Release` → `dotnet nuget push ShareInvest.Agency.0.16.2.nupkg`
2. P5 `Models.csproj` bump from 0.16.1 → 0.16.2
3. Re-trigger P5 Build & Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)