### PR TITLE
fix(studio-mint): drop unsupported output_format from edit options (0.16.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.16.6] — 2026-04-24
+
+### Fixed
+- **Drop `ImageEditOptions.Quality` in `GenerateSingleShotAsync`** — OpenAI .NET SDK 2.10.0 serializes this property in a shape the `POST /v1/images/edits` endpoint rejects as `HTTP 400 (invalid_request_error: unknown_parameter: quality)`, despite OpenAI's REST API accepting `quality=high` on the same endpoint for the same model when the request is built by hand. Reproduced in an isolated .NET 10 probe on 2026-04-24 against `gpt-image-2`. Empirically, removing `Quality` while keeping `Size` + `OutputFileFormat` + `EndUserId` makes the call succeed; all other single-field probes (`Size` only, `OutputFileFormat` only, `Size+OutputFileFormat+EndUserId`) also succeed. Only the presence of `Quality` in the options bag triggers the reject.
+
+### Known upstream issue
+- Root cause lives in `OpenAI.Images.ImageEditOptions` in the OpenAI .NET SDK 2.10.0. The public generations endpoint (which StudioMint does not use) appears to accept the same property correctly, so the regression is specific to the edit path's serialization. Tracking for SDK upgrade when a fix lands. Until then, we rely on the server's default `quality=auto`, which is acceptable for the v1 4-cut output.
+
+### Notes
+- Purely behavioural — no API surface changes. P5 consumers do not need to touch their wiring beyond bumping the NuGet reference.
+
+---
+
 ## [0.16.5] — 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.16.5] — 2026-04-24
+
+### Fixed
+- **Restore the 4-param `GptService` constructor as a binary-compatible overload** (Codex review feedback on 0.16.4). 0.16.4 replaced `GptService(ILogger<GptService>, string, string, string?)` with a 5-param variant that had an optional `imageGenerationModel = null` at the end. C# treats that as the same *source* signature but emits a different *IL* signature — assemblies compiled against ≤0.16.2 would therefore hit `MissingMethodException` at runtime when loaded with 0.16.4. The 5-param overload is retained (with the default value removed so the two don't overlap ambiguously); the old 4-param overload now delegates to it with `imageGenerationModel: null`, preserving the ≤0.16.2 behaviour byte-for-byte.
+
+### Notes
+- **NuGet consumers: bump `Models.csproj`** in P5 (creative-server) to `Version="0.16.5"`. 0.16.4 remains on nuget.org for history; use 0.16.5 or later to avoid the binary-compat trap for any downstream consumer that did not recompile.
+
+---
+
+## [0.16.4] — 2026-04-24
+
+### Changed
+- **Split the image model into two knobs** on `GptService`: `imageModel` (edit endpoint, StudioMint) and `imageGenerationModel` (generations endpoint, PageMint). Adds a new optional constructor parameter `imageGenerationModel` on both the API-key and `OpenAIClientOptions` overloads. Falls back to `imageModel` when null so old callers keep working without changes. Enables consumers (P5) to route StudioMint to `gpt-image-2` while keeping PageMint's high-volume generations on the cheaper `gpt-image-1-mini`.
+- **Restore full `ImageEditOptions` set for StudioMint**: `Size = 1024x1024`, `Quality = High`, `OutputFileFormat = Png`, `EndUserId = userId`. 0.16.3 stripped these because `gpt-image-1` / `gpt-image-1-mini` rejected them on the public edit endpoint as `unknown_parameter`. Now that the expected edit model is `gpt-image-2`, which accepts the full set per the Azure Foundry spec for gpt-image-series, they're safe again.
+- **Drop `SupportsFullEditOptions` gating** introduced mid-0.16.4 review. With the edit model pinned to `gpt-image-2`+ via the split, the model-aware fallback is no longer needed. Simpler and one fewer concept to carry.
+
+### Known issue
+- **Binary-compat regression** on the `GptService(ILogger, string, string, string?)` constructor: the signature was widened to 5 params with an optional `imageGenerationModel = null`, which changes the IL surface. Source-compatible, but assemblies compiled against ≤0.16.2 can hit `MissingMethodException` at runtime. **Fixed in 0.16.5.**
+
+### Notes
+- Superseded by 0.16.5 for the binary-compat issue above. Functionally correct otherwise.
+
+---
+
+## [0.16.3] — 2026-04-24
+
+### Fixed
+- **Drop unsupported `output_format` from `ImageEditOptions` in `GenerateSingleShotAsync`.** The OpenAI `gpt-image-1` public edit endpoint (`POST /v1/images/edits`) rejects `output_format` as `unknown_parameter`, unlike the generations endpoint that accepts it. The SDK's `ImageEditOptions` exposes the property on both paths, so the compiler can't catch the cross-endpoint leak. Empirically confirmed on 2026-04-24 via the first real-DB StudioMint run from `jim@mint.surf` — all 4 shots failed `HTTP 400 (invalid_request_error: unknown_parameter) Parameter: output_format`. Removing the assignment lets the edit endpoint use its PNG default, matching what the call site wanted anyway.
+
+### Added
+- **`ClassifyBadRequest(string?)` helper + `ErrorReason = "bad_request"`** for HTTP 400 responses that are *not* content-policy rejections. The previous catch block labeled every 400 as `"moderation"`, which masked this regression behind a user-safe-looking label. New logic matches `moderation_blocked` / `content_policy_violation` substrings (case-insensitive) and returns `"moderation"` only for genuine policy blocks; everything else (parameter shape, invalid image, etc.) now surfaces as `"bad_request"` in logs and the `StudioMintShot.ErrorReason` field.
+- **6 unit tests covering the classifier**: null / empty / moderation_blocked / content_policy_violation / unknown_parameter (regression) / case-insensitive matching.
+
+### Superseded
+- **0.16.3 is retained on nuget.org for history but superseded by 0.16.4.** The edit options were stripped in 0.16.3 to work around gpt-image-1's rejection; 0.16.4 restores the full set after the image model is pinned to gpt-image-2.
+
+---
+
 ## [0.16.2] — 2026-04-23
 
 ### Fixed

--- a/agency.tests/StudioMintTests.cs
+++ b/agency.tests/StudioMintTests.cs
@@ -97,6 +97,53 @@ public class StudioMintTests
         Assert.Equal(prompts.Length, prompts.Distinct().Count());
     }
 
+    // ─── ClassifyBadRequest — separates moderation from generic 400s ─────────
+
+    [Fact]
+    public void ClassifyBadRequest_NullMessage_ReturnsBadRequest()
+    {
+        Assert.Equal("bad_request", GptService.ClassifyBadRequest(null));
+    }
+
+    [Fact]
+    public void ClassifyBadRequest_EmptyMessage_ReturnsBadRequest()
+    {
+        Assert.Equal("bad_request", GptService.ClassifyBadRequest(string.Empty));
+    }
+
+    [Fact]
+    public void ClassifyBadRequest_ModerationBlocked_ReturnsModeration()
+    {
+        // Real OpenAI body snippet for a content-policy rejection.
+        var message = "HTTP 400 (invalid_request_error: moderation_blocked) ...";
+        Assert.Equal("moderation", GptService.ClassifyBadRequest(message));
+    }
+
+    [Fact]
+    public void ClassifyBadRequest_ContentPolicyViolation_ReturnsModeration()
+    {
+        var message = "HTTP 400 ... content_policy_violation ...";
+        Assert.Equal("moderation", GptService.ClassifyBadRequest(message));
+    }
+
+    [Fact]
+    public void ClassifyBadRequest_UnknownParameter_ReturnsBadRequest()
+    {
+        // This is the exact shape of the regression that was silently masked
+        // as "moderation" in 0.16.2 when OutputFileFormat leaked into the edit
+        // request (`output_format` unsupported on the edits endpoint).
+        var message = "HTTP 400 (invalid_request_error: unknown_parameter) " +
+                      "Parameter: output_format\n\nUnknown parameter: 'output_format'.";
+        Assert.Equal("bad_request", GptService.ClassifyBadRequest(message));
+    }
+
+    [Fact]
+    public void ClassifyBadRequest_IsCaseInsensitive()
+    {
+        Assert.Equal("moderation", GptService.ClassifyBadRequest("MODERATION_BLOCKED"));
+        Assert.Equal("moderation", GptService.ClassifyBadRequest("Content_Policy_Violation"));
+    }
+
     // ─── Embedded base prompt resource (ADR-013) ─────────────────────────────
 
     [Fact]

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.16.4</Version>
+		<Version>0.16.5</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.16.3</Version>
+		<Version>0.16.4</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.16.2</Version>
+		<Version>0.16.3</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/Agency.csproj
+++ b/agency/Agency.csproj
@@ -8,7 +8,7 @@
 
 		<!-- NuGet Package -->
 		<PackageId>ShareInvest.Agency</PackageId>
-		<Version>0.16.5</Version>
+		<Version>0.16.6</Version>
 		<Authors>cyberprophet</Authors>
 		<Company>ShareInvest Corp.</Company>
 		<Copyright>Copyright ⓒ 2026, ShareInvest Corp.</Copyright>

--- a/agency/OpenAI/GptService.Image.cs
+++ b/agency/OpenAI/GptService.Image.cs
@@ -28,7 +28,11 @@ public partial class GptService
     {
         var size = MapSize(request.AspectRatio);
 
-        var imageClient = GetImageClient(imageModel);
+        // PageMint generations intentionally routes through a separate
+        // model knob so it can use a cheaper variant (e.g., gpt-image-1-mini)
+        // independent of StudioMint's edit-endpoint model (gpt-image-2).
+        var effectiveModel = EffectiveImageGenerationModel;
+        var imageClient = GetImageClient(effectiveModel);
 
         var options = new ImageGenerationOptions
         {
@@ -61,7 +65,7 @@ public partial class GptService
                 // ModelPricingTable can bill each bucket at its own rate.
                 var textInput = (int)(usage?.InputTokenDetails?.TextTokenCount ?? usage?.InputTokenCount ?? 0);
                 var imageInput = (int)(usage?.InputTokenDetails?.ImageTokenCount ?? 0);
-                onUsage(new ApiUsageEvent(ProviderName, imageModel ?? "gpt-image-1",
+                onUsage(new ApiUsageEvent(ProviderName, effectiveModel ?? "gpt-image-1",
                     textInput,
                     (int)(usage?.OutputTokenCount ?? 0),
                     "image", LatencyMs: (int)sw.ElapsedMilliseconds,

--- a/agency/OpenAI/GptService.StudioMint.cs
+++ b/agency/OpenAI/GptService.StudioMint.cs
@@ -79,11 +79,17 @@ public partial class GptService
         {
             var imageClient = GetImageClient(imageModel);
 
+            // Do NOT set OutputFileFormat here. The OpenAI gpt-image-1
+            // edit endpoint (`POST /v1/images/edits`) rejects `output_format`
+            // as `unknown_parameter` — unlike the generations endpoint, which
+            // accepts it (see `GptService.Image.cs`). The SDK's
+            // `ImageEditOptions` exposes the property anyway, so the
+            // compiler can't catch this. The edit endpoint returns PNG by
+            // default, which is what we want.
             var options = new ImageEditOptions
             {
                 Size = GeneratedImageSize.W1024xH1024,
                 Quality = GeneratedImageQuality.High,
-                OutputFileFormat = GeneratedImageFileFormat.Png,
                 EndUserId = request.UserId
             };
 
@@ -131,9 +137,13 @@ public partial class GptService
         }
         catch (ClientResultException ex) when (ex.Status == 400)
         {
-            logger.LogWarning(ex, "StudioMint shot {ShotType} blocked by moderation: {Message}", shot.Id, ex.Message);
+            var reason = ClassifyBadRequest(ex.Message);
+            logger.LogWarning(
+                ex,
+                "StudioMint shot {ShotType} failed with HTTP 400 ({Reason}): {Message}",
+                shot.Id, reason, ex.Message);
 
-            return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: "moderation");
+            return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: reason);
         }
         catch (ClientResultException ex) when (ex.Status == 401)
         {
@@ -159,6 +169,31 @@ public partial class GptService
 
             return new StudioMintShot(index, shot.Id, ImageBytes: null, ErrorReason: "unexpected");
         }
+    }
+
+    /// <summary>
+    /// Classifies an OpenAI HTTP 400 response into a stable <see cref="StudioMintShot.ErrorReason"/>
+    /// token. The OpenAI edit endpoint returns 400 for two very different reasons:
+    /// content-policy rejections (moderation) and request-shape problems (unknown parameter,
+    /// invalid image, etc.). Collapsing both into <c>"moderation"</c> as the old code did
+    /// masked real bugs (e.g., the <c>output_format</c> regression in 0.16.2) behind a
+    /// user-safe-looking label.
+    /// </summary>
+    /// <remarks>
+    /// We look at the plain-text body of the exception since <c>ClientResultException</c>
+    /// doesn't expose OpenAI's <c>error.code</c> field as a structured property. OpenAI's
+    /// moderation rejections carry identifiable markers — <c>moderation_blocked</c> or
+    /// <c>content_policy_violation</c>. Anything else in 400 territory is treated as
+    /// <c>bad_request</c> so the failure surfaces honestly in logs and the DB.
+    /// </remarks>
+    internal static string ClassifyBadRequest(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return "bad_request";
+        if (message.Contains("moderation_blocked", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("content_policy_violation", StringComparison.OrdinalIgnoreCase))
+            return "moderation";
+        return "bad_request";
     }
 
     /// <summary>

--- a/agency/OpenAI/GptService.StudioMint.cs
+++ b/agency/OpenAI/GptService.StudioMint.cs
@@ -79,17 +79,30 @@ public partial class GptService
         {
             var imageClient = GetImageClient(imageModel);
 
-            // Do NOT set OutputFileFormat here. The OpenAI gpt-image-1
-            // edit endpoint (`POST /v1/images/edits`) rejects `output_format`
-            // as `unknown_parameter` — unlike the generations endpoint, which
-            // accepts it (see `GptService.Image.cs`). The SDK's
-            // `ImageEditOptions` exposes the property anyway, so the
-            // compiler can't catch this. The edit endpoint returns PNG by
-            // default, which is what we want.
+            // Tuned for the `gpt-image-2` edit endpoint (the default for
+            // StudioMint since 0.16.4 — configured via `Agency.Models.Image`
+            // in P5). Per the Azure Foundry REST spec for
+            // `POST /openai/v1/images/edits`, gpt-image-2 accepts
+            // `size`, `quality`, `output_format`, `background`, `user`.
+            //
+            // Defaults for 4-cut commerce product shots:
+            //   Size             = 1024x1024 (square, PageMint asset ratio)
+            //   Quality          = High      (paid output; auto can fall to medium)
+            //   OutputFileFormat = Png       (lossless, no compression artefacts)
+            //   EndUserId        = userId    (abuse / support traceability)
+            //
+            // NOTE: `gpt-image-1` and `gpt-image-1-mini` reject `quality`
+            // and `output_format` as `unknown_parameter`. If P5 ever
+            // reconfigures `Agency.Models.Image` to a legacy model,
+            // StudioMint will 400 until it's set back to gpt-image-2 or
+            // later. PageMint's generations path uses a separate config
+            // key (`Agency.Models.PageMintImage`) and still points at
+            // gpt-image-1-mini for cost.
             var options = new ImageEditOptions
             {
                 Size = GeneratedImageSize.W1024xH1024,
                 Quality = GeneratedImageQuality.High,
+                OutputFileFormat = GeneratedImageFileFormat.Png,
                 EndUserId = request.UserId
             };
 

--- a/agency/OpenAI/GptService.StudioMint.cs
+++ b/agency/OpenAI/GptService.StudioMint.cs
@@ -79,29 +79,30 @@ public partial class GptService
         {
             var imageClient = GetImageClient(imageModel);
 
-            // Tuned for the `gpt-image-2` edit endpoint (the default for
-            // StudioMint since 0.16.4 — configured via `Agency.Models.Image`
-            // in P5). Per the Azure Foundry REST spec for
-            // `POST /openai/v1/images/edits`, gpt-image-2 accepts
-            // `size`, `quality`, `output_format`, `background`, `user`.
+            // Tuned for the `gpt-image-2` edit endpoint (default for
+            // StudioMint since 0.16.4, configured via `Agency.Models.Image`
+            // in P5).
             //
-            // Defaults for 4-cut commerce product shots:
+            // `Quality` is intentionally **NOT** set. OpenAI's public
+            // REST API accepts `quality=high` on this endpoint (verified
+            // 2026-04-24 via curl against gpt-image-2), but the OpenAI
+            // .NET SDK 2.10.0 serializes `ImageEditOptions.Quality` in a
+            // shape the edit endpoint rejects as
+            // `HTTP 400 (invalid_request_error: unknown_parameter: quality)`.
+            // The failure was reproduced in an isolated probe against
+            // 2.10.0; `Size`/`OutputFileFormat`/`EndUserId` alone work
+            // unchanged. Until the SDK fixes the quality serialization,
+            // we let the server default (`auto`) pick the quality tier
+            // — acceptable for v1 4-cut output. Revisit when the SDK is
+            // upgraded past 2.10.0.
+            //
+            // Kept defaults for 4-cut commerce product shots:
             //   Size             = 1024x1024 (square, PageMint asset ratio)
-            //   Quality          = High      (paid output; auto can fall to medium)
-            //   OutputFileFormat = Png       (lossless, no compression artefacts)
+            //   OutputFileFormat = Png       (lossless, no compression)
             //   EndUserId        = userId    (abuse / support traceability)
-            //
-            // NOTE: `gpt-image-1` and `gpt-image-1-mini` reject `quality`
-            // and `output_format` as `unknown_parameter`. If P5 ever
-            // reconfigures `Agency.Models.Image` to a legacy model,
-            // StudioMint will 400 until it's set back to gpt-image-2 or
-            // later. PageMint's generations path uses a separate config
-            // key (`Agency.Models.PageMintImage`) and still points at
-            // gpt-image-1-mini for cost.
             var options = new ImageEditOptions
             {
                 Size = GeneratedImageSize.W1024xH1024,
-                Quality = GeneratedImageQuality.High,
                 OutputFileFormat = GeneratedImageFileFormat.Png,
                 EndUserId = request.UserId
             };

--- a/agency/OpenAI/GptService.cs
+++ b/agency/OpenAI/GptService.cs
@@ -43,6 +43,23 @@ public partial class GptService : ITextGenerationProvider, IVisionProvider, IIma
     /// Initializes a new instance of <see cref="GptService"/> with the specified logger, API key,
     /// custom image model name, and optional Exa API key for web research.
     /// </summary>
+    /// <remarks>
+    /// Kept for binary compatibility with assemblies compiled against
+    /// ≤0.16.2. Delegates to the 5-param overload with a null
+    /// generations model so callers that didn't know about
+    /// <c>imageGenerationModel</c> get the old behaviour
+    /// (generations share <paramref name="imageModel"/>).
+    /// </remarks>
+    public GptService(ILogger<GptService> logger, string apiKey, string imageModel, string? exaApiKey)
+        : this(logger, apiKey, imageModel, exaApiKey, imageGenerationModel: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GptService"/> with separate
+    /// image models for the edit endpoint (StudioMint) and the generations
+    /// endpoint (PageMint). Added in 0.16.4.
+    /// </summary>
     /// <param name="logger">Logger instance for diagnostic output.</param>
     /// <param name="apiKey">OpenAI API key.</param>
     /// <param name="imageModel">
@@ -51,14 +68,14 @@ public partial class GptService : ITextGenerationProvider, IVisionProvider, IIma
     /// </param>
     /// <param name="exaApiKey">Optional Exa API key for web research.</param>
     /// <param name="imageGenerationModel">
-    /// Optional separate model for the generations endpoint
+    /// Separate model for the generations endpoint
     /// (<see cref="GenerateImageAsync{T}"/>). When null, falls back to
     /// <paramref name="imageModel"/>. Set this so PageMint's
     /// generations path and StudioMint's edit path can target different
     /// models (e.g., <c>gpt-image-1-mini</c> for cheap generations and
     /// <c>gpt-image-2</c> for high-fidelity edits).
     /// </param>
-    public GptService(ILogger<GptService> logger, string apiKey, string imageModel, string? exaApiKey, string? imageGenerationModel = null)
+    public GptService(ILogger<GptService> logger, string apiKey, string imageModel, string? exaApiKey, string? imageGenerationModel)
     {
         client = new OpenAIClient(apiKey);
         this.logger = logger;

--- a/agency/OpenAI/GptService.cs
+++ b/agency/OpenAI/GptService.cs
@@ -43,11 +43,27 @@ public partial class GptService : ITextGenerationProvider, IVisionProvider, IIma
     /// Initializes a new instance of <see cref="GptService"/> with the specified logger, API key,
     /// custom image model name, and optional Exa API key for web research.
     /// </summary>
-    public GptService(ILogger<GptService> logger, string apiKey, string imageModel, string? exaApiKey)
+    /// <param name="logger">Logger instance for diagnostic output.</param>
+    /// <param name="apiKey">OpenAI API key.</param>
+    /// <param name="imageModel">
+    /// Model used by the edit endpoint (StudioMint). Also the fallback for
+    /// generations if <paramref name="imageGenerationModel"/> is null.
+    /// </param>
+    /// <param name="exaApiKey">Optional Exa API key for web research.</param>
+    /// <param name="imageGenerationModel">
+    /// Optional separate model for the generations endpoint
+    /// (<see cref="GenerateImageAsync{T}"/>). When null, falls back to
+    /// <paramref name="imageModel"/>. Set this so PageMint's
+    /// generations path and StudioMint's edit path can target different
+    /// models (e.g., <c>gpt-image-1-mini</c> for cheap generations and
+    /// <c>gpt-image-2</c> for high-fidelity edits).
+    /// </param>
+    public GptService(ILogger<GptService> logger, string apiKey, string imageModel, string? exaApiKey, string? imageGenerationModel = null)
     {
         client = new OpenAIClient(apiKey);
         this.logger = logger;
         this.imageModel = imageModel;
+        this.imageGenerationModel = imageGenerationModel;
         webTools = new WebTools(exaApiKey);
     }
 
@@ -57,14 +73,19 @@ public partial class GptService : ITextGenerationProvider, IVisionProvider, IIma
     /// <param name="logger">Logger instance for diagnostic output.</param>
     /// <param name="apiKey">Provider API key.</param>
     /// <param name="options">Client options with custom <see cref="OpenAIClientOptions.Endpoint"/>.</param>
-    /// <param name="imageModel">Name of the image model to use for image generation.</param>
+    /// <param name="imageModel">Name of the image model to use for image editing (StudioMint).</param>
     /// <param name="exaApiKey">Optional Exa API key for web research.</param>
     /// <param name="providerName">Provider name for telemetry (e.g., "groq", "minimax").</param>
-    public GptService(ILogger<GptService> logger, string apiKey, OpenAIClientOptions options, string? imageModel = null, string? exaApiKey = null, string providerName = "openai")
+    /// <param name="imageGenerationModel">
+    /// Optional separate model for the generations endpoint. Falls back
+    /// to <paramref name="imageModel"/> when null.
+    /// </param>
+    public GptService(ILogger<GptService> logger, string apiKey, OpenAIClientOptions options, string? imageModel = null, string? exaApiKey = null, string providerName = "openai", string? imageGenerationModel = null)
     {
         client = new OpenAIClient(new System.ClientModel.ApiKeyCredential(apiKey), options);
         this.logger = logger;
         this.imageModel = imageModel;
+        this.imageGenerationModel = imageGenerationModel;
         this.providerName = providerName;
         webTools = new WebTools(exaApiKey);
     }
@@ -75,8 +96,16 @@ public partial class GptService : ITextGenerationProvider, IVisionProvider, IIma
     readonly OpenAIClient client;
     readonly ILogger<GptService> logger;
     readonly string? imageModel;
+    readonly string? imageGenerationModel;
     readonly string providerName = "openai";
     readonly WebTools webTools;
+
+    /// <summary>
+    /// Model used by the generations endpoint (<see cref="GenerateImageAsync{T}"/>).
+    /// Falls back to <see cref="imageModel"/> when an explicit
+    /// generations model wasn't configured.
+    /// </summary>
+    internal string? EffectiveImageGenerationModel => imageGenerationModel ?? imageModel;
 
     /// <summary>Gets a chat client for the specified model from the composed <see cref="OpenAIClient"/>.</summary>
     internal virtual ChatClient GetChatClient(string model) => client.GetChatClient(model);


### PR DESCRIPTION
## Summary
- Remove \`OutputFileFormat = GeneratedImageFileFormat.Png\` from \`ImageEditOptions\` in \`GptService.GenerateSingleShotAsync\`. The OpenAI gpt-image-1 edit endpoint (\`POST /v1/images/edits\`) rejects \`output_format\` as \`unknown_parameter\`; generations endpoint accepts it but edits endpoint does not. Edit endpoint returns PNG by default.
- Extract \`ClassifyBadRequest(string?)\` so the 400 handler distinguishes \`moderation\` (policy rejections) from \`bad_request\` (parameter/shape bugs) — prior code labeled every 400 as \`moderation\`, which masked this regression for 10 days.
- Bump version \`0.16.2 → 0.16.3\`. Published to nuget.org.

## Why
First real StudioMint job ever in the shared DB (jim@mint.surf, 2026-04-24 00:30:36 UTC) failed all 4 shots with:
\`\`\`
HTTP 400 (invalid_request_error: unknown_parameter)
Parameter: output_format
\`\`\`
Logs surfaced as \"blocked by moderation\" because of the over-broad 400 catch. Root cause is a cross-endpoint options-class leak in the OpenAI SDK — compile-time check doesn't exist. Intent 031 initial commit carried the regression from day one; caught only when the edit endpoint saw a real request.

## Test plan
- [x] \`dotnet test --filter \"FullyQualifiedName~StudioMint\"\` — 52/52 pass
- [x] \`ClassifyBadRequest\` covers null / empty / moderation_blocked / content_policy_violation / unknown_parameter / case-insensitive (6 new tests)
- [x] \`dotnet pack -c Release\` succeeds
- [x] \`dotnet nuget push 0.16.3\` succeeds
- [ ] P5 ShareInvest.Agency bump + local server restart + real end-to-end retry via jim's account

## Follow-up
- P5 PR bumps \`ShareInvest.Agency\` PackageReference to 0.16.3.
- If the SDK ever reshapes \`ImageEditOptions\` to drop the property, delete the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)